### PR TITLE
Harden worker selection and session accounting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
 
   proxy-tests:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       
@@ -39,6 +49,8 @@ jobs:
       
       - name: Run proxy unit tests
         working-directory: ./proxy
+        env:
+          TEST_REDIS_ADDR: 127.0.0.1:6379
         run: go test -v ./...
 
   docker-build:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ That's it! The same `ws://localhost:8080` endpoint works with any Playwright cli
 - A successful `connect()` returns a normal Playwright `Browser`. Create contexts with `browser.newContext()` or use `browser.newPage()` as the single-page convenience path.
 - Contexts created through one client connection are isolated from other client connections.
 - `PROXY_READ_HEADER_TIMEOUT` limits how long the server waits for request headers.
-- `PROXY_WORKER_SELECTION_TIMEOUT` is the main queue-wait timeout: if no matching worker is eligible on a given attempt, the proxy keeps retrying until this timeout expires.
-- `PROXY_CONNECT_TIMEOUT` starts only after a worker is selected and covers backend worker dial plus the client handshake response write.
+- `PROXY_WORKER_SELECTION_TIMEOUT` is the main queue-wait timeout: if no matching worker is eligible, or a selected worker fails fast before handoff succeeds, the proxy keeps retrying until this timeout expires.
+- `PROXY_CONNECT_TIMEOUT` gives the first selected-worker handoff its full budget. During reselection, later attempts can be shorter because the remaining `PROXY_WORKER_SELECTION_TIMEOUT` budget still wins.
 - Breaking change: `PROXY_CONNECT_TIMEOUT` no longer means the whole pre-upgrade path.
 - Proxy-owned failures are returned as JSON until the client WebSocket upgrade begins:
 
@@ -89,6 +89,8 @@ That's it! The same `ws://localhost:8080` endpoint works with any Playwright cli
   - `worker selection timed out`
   - `connect timed out after selecting worker`
   - `selected worker unavailable`
+- `selected worker unavailable` means the proxy saw a fast selected-worker failure and could not complete the handoff with another worker before the selection budget was exhausted.
+- Fast retry-path rollback happens in the background so slow Redis bookkeeping does not delay reselection. The tradeoff is that `allocated_sessions` can stay temporarily inflated while rollback catches up, but worker drain timing still follows committed successful sessions.
 - If Gorilla has already started the client upgrade handshake, the proxy still logs the exact failure and rolls back worker bookkeeping, but it may close the connection instead of returning a fresh JSON error body.
 - Malformed WebSocket handshakes after upgrade headers are present use standards-aligned HTTP responses instead of JSON:
   - `405 Method Not Allowed` for non-`GET` requests
@@ -205,7 +207,7 @@ flowchart TD
 2. **Contexts are created by the client** – use `browser.newContext()` or `browser.newPage()` after `connect()`.
 3. **Concurrent sessions** – each worker serves several client connections and contexts in parallel.
 4. **Recycling** – after serving a configurable number of sessions the worker shuts down; Docker/K8s restarts it to keep browser processes fresh.
-5. **Smart worker selection** – the proxy's algorithm keeps workers from hitting their restart threshold at the same time and still favours the busiest eligible worker.
+5. **Smart worker selection** – the proxy's algorithm keeps workers from hitting their restart threshold at the same time and still favours the least-loaded eligible worker.
 
 
 ## 🗺️ Roadmap

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -15,6 +15,8 @@ services:
       - MAX_CONCURRENT_SESSIONS=5
       # Maximum number of sessions a worker will handle before it is recycled. The proxy tracks this for each worker.
       - MAX_LIFETIME_SESSIONS=50
+      # Maximum age of a worker heartbeat before the selector considers that worker stale.
+      - SELECTOR_FRESHNESS_TIMEOUT=60
       # Maximum time to read client request headers before the proxy handler runs.
       - PROXY_READ_HEADER_TIMEOUT=5
       # Maximum time to keep retrying until a matching worker becomes available.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - MAX_CONCURRENT_SESSIONS=5
       # Maximum number of sessions a worker will handle before it is recycled. The proxy tracks this for each worker.
       - MAX_LIFETIME_SESSIONS=50
+      # Maximum age of a worker heartbeat before the selector considers that worker stale.
+      - SELECTOR_FRESHNESS_TIMEOUT=60
       # Maximum time to read client request headers before the proxy handler runs.
       - PROXY_READ_HEADER_TIMEOUT=5
       # Maximum time to keep retrying until a matching worker becomes available.

--- a/docs/SELECTOR.md
+++ b/docs/SELECTOR.md
@@ -1,132 +1,134 @@
 # Worker Selection Strategy
 
-This document explains how the proxy selects workers from the available pool and why this strategy helps maintain system stability.
+This document explains how the proxy chooses a worker and why the selector is intentionally biased toward both healthy load distribution and staggered worker recycling.
 
 ## Overview
 
-The worker selector in `proxy/internal/redis/selector.lua` implements a **lifetime-first selection strategy** designed to prevent multiple workers from reaching their session limit simultaneously, which would cause multiple restarts at the same time and temporarily reduce cluster capacity.
+The selector in `proxy/internal/redis/selector.lua` now uses **balanced routing with restart bias**.
 
-## Strategy Details
+That means:
 
-### Primary Goal: Stagger Worker Restarts
+- route only to healthy, eligible workers
+- prefer the least-loaded eligible worker first
+- keep an allocated-session safety margin so workers do not all hit their recycle limit at the same time
+- stay deterministic so behavior is predictable and easy to test
 
-Instead of distributing load evenly across all workers (which causes them to reach their limits at the same time), we intentionally "push" one worker to its limit first while keeping others behind. This ensures only one worker restarts at a time.
+The selector still runs in Redis/Lua because selection and counter increment must stay atomic.
 
-### Worker Discovery
+The selector uses `cluster:allocated_sessions` as its optimistic lifetime budget counter. Worker drain decisions use `cluster:successful_sessions` instead. That split keeps async rollback from draining a healthy worker one session early.
 
-Workers are pre-registered in the `cluster:active_connections` hash on startup with an initial value of 0. This ensures all workers are visible to the selection algorithm, including those with zero active connections.
+## Eligibility Rules
 
-### Selection Algorithm
+A worker is eligible only if all of these are true:
 
-1. **Early exit**: If no workers are available in the cluster, return `nil` immediately to prevent errors.
+- browser type matches the requested browser
+- status is `available`
+- active connections are below `MAX_CONCURRENT_SESSIONS`
+- allocated sessions are below `MAX_LIFETIME_SESSIONS`
+- `lastHeartbeat` is within `SELECTOR_FRESHNESS_TIMEOUT`
+- the worker metadata needed for routing is present and well-formed
+- the worker is not excluded for the current connection attempt
 
-2. **Filter eligible workers** based on:
-   - Status is "available"
-   - Active connections < `MAX_CONCURRENT_SESSIONS`
-   - Lifetime connections < `MAX_LIFETIME_SESSIONS`
-   - Recent heartbeat (within last 60 seconds)
+The selector ignores orphan counter entries that no longer have a valid worker record. Cleanup of those stale counters remains the reaper's job.
 
-3. **Calculate adaptive safety margin**:
-   ```
-   margin = max(1, floor(MAX_LIFETIME_SESSIONS / total_workers))
-   ```
+## Selection Algorithm
 
-4. **Primary selection** (respecting safety margin):
-   - Among workers with `lifetime < (MAX_LIFETIME_SESSIONS - margin)`
-   - Select worker with **highest lifetime** connections
-   - Tie-break with **lowest active** connections
+The selector uses two tiers.
 
-5. **Fallback selection** (respects hard limit):
-   - If no workers pass the margin check
-   - Among workers with `lifetime + 1 <= MAX_LIFETIME_SESSIONS`
-   - Select worker with **highest lifetime** connections
-   - Tie-break with **lowest active** connections
+### 1. Tier 1: Headroom Tier
 
-## Example Scenarios
+Workers in this tier satisfy:
 
-### Scenario 1: Normal Operation
-- **Setup**: 4 workers, `MAX_LIFETIME_SESSIONS = 20`
-- **Margin**: `max(1, floor(20/4)) = 5`
-- **Current state**:
-  ```
-  Worker A: lifetime=18, active=2  # Within margin (18 >= 15), not selectable
-  Worker B: lifetime=12, active=1  # Best choice (highest lifetime under margin)
-  Worker C: lifetime=8,  active=0
-  Worker D: lifetime=3,  active=1
-  ```
-- **Result**: Worker B is selected
-- **Rationale**: Worker A is close to its limit, so we avoid it. Worker B has done the most work among the remaining candidates.
+```text
+allocated < MAX_LIFETIME_SESSIONS - margin
+```
 
-### Scenario 2: Small Cluster with High Load
-- **Setup**: 2 workers, `MAX_LIFETIME_SESSIONS = 10`
-- **Margin**: `max(1, floor(10/2)) = 5`
-- **Current state**:
-  ```
-  Worker A: lifetime=8, active=3   # Within margin (8 >= 5), not selectable
-  Worker B: lifetime=7, active=2   # Within margin (7 >= 5), not selectable
-  ```
-- **Fallback triggered**: Both workers are within margin
-- **Result**: Worker A is selected (highest lifetime, and 8+1 <= 10)
-- **Rationale**: System prioritizes progress over perfect staggering when necessary, but never exceeds the hard limit.
+The margin is computed from the number of **eligible** workers for the requested browser:
 
-### Scenario 3: Development Environment
-- **Setup**: 1 worker, `MAX_LIFETIME_SESSIONS = 4`
-- **Margin**: `max(1, floor(4/1)) = 4`
-- **Current state**:
-  ```
-  Worker A: lifetime=2, active=0   # Under margin (2 < 0), selectable
-  ```
-- **Result**: Worker A is selected
-- **Rationale**: With only one worker, we can't stagger, but the margin prevents issues at the boundary.
+```text
+margin = max(1, floor(MAX_LIFETIME_SESSIONS / eligible_workers))
+```
 
-### Scenario 4: Edge Case - Worker at Limit
-- **Setup**: 3 workers, `MAX_LIFETIME_SESSIONS = 10`
-- **Margin**: `max(1, floor(10/3)) = 3`
-- **Current state**:
-  ```
-  Worker A: lifetime=9, active=1   # At limit-1, can be selected by fallback (9+1 <= 10)
-  Worker B: lifetime=7, active=2   # Within margin (7 >= 7), not selectable in primary
-  Worker C: lifetime=5, active=0   # Best primary choice (highest under margin)
-  ```
-- **Result**: Worker C is selected (primary selection)
-- **Rationale**: Primary selection prefers Worker C. If Worker C were unavailable, fallback would select Worker A but never Worker B at lifetime=10.
+This keeps workers with enough allocated headroom in the preferred pool and prevents the selector from pushing every worker toward the recycle edge at the same rate.
 
-## Benefits
+### 2. Tier 2: Fallback Tier
 
-### 1. **Predictable Capacity**
-- Only one worker restarts at a time
-- Cluster maintains `(N-1)/N` capacity during restarts instead of dropping significantly
+If Tier 1 is empty, the selector falls back to any remaining eligible worker that still stays under the hard lifetime limit for one more session:
 
-### 2. **Load Distribution**
-- Active connection tie-breaker prevents overloading busy workers
-- System remains responsive under concurrent load
+```text
+allocated + 1 <= MAX_LIFETIME_SESSIONS
+```
 
-### 3. **Adaptive Behavior**
-- Margin scales with cluster size automatically
-- Works efficiently for both small dev clusters and large production deployments
+This fallback keeps the system making progress under pressure without violating the hard limit.
 
-### 4. **Performance**
-- O(N) algorithm - single pass through workers
+## Ranking Inside a Tier
 
-### 5. **Robustness**
-- Guards against edge cases (empty worker pool, division by zero)
-- Guarantees compliance with hard lifetime limits
-- All workers visible regardless of current active connection count
+Within either tier, workers are ranked in this order:
+
+1. lower active connections
+2. higher allocated sessions
+3. older `startedAt`
+4. lexicographically smaller worker ID
+
+Why this order:
+
+- lower active connections keeps routing load-aware
+- higher allocated sessions keep the restart-staggering bias
+- older `startedAt` breaks ties in a stable way
+- worker ID is the final deterministic tiebreaker
+
+## Why This Replaced Pure Lifetime-First Routing
+
+The previous lifetime-first strategy did stagger restarts, but it over-prioritized lifetime even when another healthy worker was less loaded.
+
+The new strategy keeps the useful part of the old behavior while fixing that imbalance:
+
+- load awareness comes first inside a tier
+- restart bias still exists through the allocated-session safety margin and the allocated-session tiebreak
+- margin calculation now depends on eligible workers, not raw counter hashes
+
+## Failure Handling Boundary
+
+The selector itself only chooses workers and increments counters atomically. Failure recovery around selection happens in the proxy handler.
+
+For one connection attempt, the proxy may exclude a selected worker and ask the selector for another one when a selected worker fails fast before the handoff succeeds, for example:
+
+- invalid worker endpoint
+- immediate backend dial failure
+- selected worker disappears before a usable handoff can be completed
+
+Those exclusions are request-scoped only. They are not a cluster-wide blacklist.
+
+The proxy does **not** use selector retries for:
+
+- backend dial timeout
+- client upgrade failure after Gorilla starts the upgrade path
+
+Those remain terminal handoff failures for that client connection.
 
 ## Configuration Impact
 
-The selection strategy interacts with these configuration values:
+The selector depends on these values:
 
-- **`MAX_CONCURRENT_SESSIONS`**: Hard limit on concurrent connections per worker
-- **`MAX_LIFETIME_SESSIONS`**: Triggers worker restart and drives the selection preference
-- **Worker count**: Automatically detected and used to calculate the safety margin
+- `MAX_CONCURRENT_SESSIONS`
+- `MAX_LIFETIME_SESSIONS`
+- `SELECTOR_FRESHNESS_TIMEOUT`
 
-## Monitoring
+`SELECTOR_FRESHNESS_TIMEOUT` is intentionally explicit now. The selector no longer relies on a hardcoded heartbeat age threshold.
 
-To observe the strategy in action, monitor:
+`MAX_LIFETIME_SESSIONS` still refers to successful sessions at the worker lifecycle level. The selector uses `allocated_sessions` conservatively against that same limit so in-flight handoffs cannot oversubscribe the worker.
 
-1. **Lifetime connection distribution** across workers
-2. **Restart timing** - should see staggered restarts, not simultaneous ones
-3. **Active connection spikes** during high load periods
+## Operational Expectations
 
-The strategy should show a "sawtooth" pattern in lifetime connections over time, with one worker climbing to the limit, restarting (dropping to 0), while others remain at intermediate levels. 
+If the selector is working correctly, you should see:
+
+- draining and stale workers stop receiving new sessions
+- lower-active healthy workers preferred over busier ones
+- allocated-session counts rise unevenly enough that worker recycling is staggered rather than synchronized
+- fast bad-worker failures retried against other workers within the selection timeout when possible
+
+The system should still show a sawtooth-style allocated-session pattern over time, but with healthier per-request load distribution than a pure lifetime-first policy.
+
+## Known Scale Tradeoff
+
+The current selector still scans Redis worker state in O(N) per selection attempt. That is intentional for the current expected pool size because it keeps selection logic deterministic and atomic inside Lua. If the worker fleet or the number of queued clients grows substantially, this design will need a different data structure rather than incremental tuning.

--- a/docs/TIMEOUTS.md
+++ b/docs/TIMEOUTS.md
@@ -8,7 +8,7 @@ This document lists the important time-based settings in the current implementat
 |---|---|---|---|---|
 | Worker Heartbeat Interval | `worker/src/config.ts` | 5s | - | How often a healthy worker refreshes its Redis record. |
 | Worker Key TTL | `worker/src/config.ts` | 60s | Worker Heartbeat | Worker metadata disappears after this if heartbeats stop. |
-| Selector Freshness Threshold | `proxy/internal/redis/selector.lua` | 60s | Worker Heartbeat | Hardcoded recent-heartbeat check used for worker eligibility. |
+| Selector Freshness Timeout | `proxy/pkg/config/config.go` | 60s | Worker Heartbeat | Configured recent-heartbeat check used for worker eligibility. |
 | Shutdown Command TTL | `proxy/pkg/config/config.go` | 60s | Worker Heartbeat | Must outlive at least one worker heartbeat cycle. |
 | Worker Drain Timeout | `worker/src/index.ts` | 300s (5m) | - | Hardcoded safety net while a draining worker waits for active connections to reach zero. |
 | Reaper Run Interval | `proxy/pkg/config/config.go` | 300s (5m) | Worker Key TTL | Reaper removes stale connection counters after worker keys have already expired. |
@@ -36,13 +36,13 @@ This document lists the important time-based settings in the current implementat
 - **Rationale**: The worker key is the source of truth for whether a worker still exists. If this TTL is too short, healthy workers can disappear and be treated as dead.
 - **Recommendation**: Keep this comfortably above the heartbeat interval, ideally several multiples rather than only one missed heartbeat.
 
-### 3. Selector Freshness Threshold
-- **Purpose**: The selector refuses workers whose `lastHeartbeat` is older than the hardcoded freshness window, even if the worker key still exists.
-- **File**: `proxy/internal/redis/selector.lua`
+### 3. Selector Freshness Timeout
+- **Purpose**: The selector refuses workers whose `lastHeartbeat` is older than the configured freshness window, even if the worker key still exists.
+- **File**: `proxy/pkg/config/config.go` (`SELECTOR_FRESHNESS_TIMEOUT`)
 - **Default**: `60` seconds
 - **Dependency Rule**: Should remain greater than `Worker Heartbeat Interval`.
 - **Rationale**: This is separate from key expiry. It filters stale workers out of routing before the reaper has cleaned up counters.
-- **Recommendation**: Keep it aligned with, or slightly below, the worker key TTL unless this value is made configurable later.
+- **Recommendation**: Keep it aligned with, or slightly below, the worker key TTL.
 
 ### 4. Shutdown Command TTL
 - **Purpose**: The TTL for `worker:cmd:{browserType}:{id}` when the proxy asks a worker to drain and shut down.
@@ -62,7 +62,7 @@ This document lists the important time-based settings in the current implementat
 - **File**: `proxy/pkg/config/config.go` (`REAPER_RUN_INTERVAL`)
 - **Default**: `300` seconds (5 minutes)
 - **Dependency Rule**: This is only useful after worker keys have already expired.
-- **Rationale**: The reaper does not use its own stale threshold. It simply removes `cluster:active_connections` and `cluster:lifetime_connections` entries whose worker key no longer exists.
+- **Rationale**: The reaper does not use its own stale threshold. It simply removes `cluster:active_connections`, `cluster:allocated_sessions`, and `cluster:successful_sessions` entries whose worker key no longer exists.
 
 ### 7. Proxy Read Header Timeout
 - **Purpose**: The maximum time the server allows for reading request headers before the handler runs.
@@ -76,14 +76,14 @@ This document lists the important time-based settings in the current implementat
 - **File**: `proxy/pkg/config/config.go` (`PROXY_WORKER_SELECTION_TIMEOUT`)
 - **Default**: `5` seconds
 - **Dependency Rule**: `HTTP WriteTimeout` must be long enough to return a structured timeout response if this phase fails.
-- **Rationale**: This is the main user-facing queue timeout. When it expires, the client-visible error is `worker selection timed out`.
+- **Rationale**: This is the main user-facing queue timeout. The proxy can spend this budget waiting for capacity and retrying after fast selected-worker failures. Only retry attempts after a fast selected-worker failure are bounded by the remaining selection budget; the first selected-worker handoff keeps the full connect timeout. Retry-path rollback happens asynchronously so slow Redis bookkeeping does not consume this wall-clock budget, at the cost of temporary `allocated_sessions` inflation while rollback catches up. Drain timing stays correct because worker shutdown uses committed `successful_sessions`, not the optimistic selector counter. If no usable worker is found before it expires, the client-visible outcome is either `worker selection timed out` or `selected worker unavailable`, depending on whether the proxy ever saw a fast selected-worker failure during the selection phase.
 
 ### 9. Proxy Connect Timeout
 - **Purpose**: The maximum time the proxy allows for backend dial and client upgrade after a worker is already selected.
 - **File**: `proxy/pkg/config/config.go` (`PROXY_CONNECT_TIMEOUT`)
 - **Default**: `5` seconds
 - **Dependency Rule**: `HTTP WriteTimeout` must be long enough to return a structured timeout response if this phase fails.
-- **Rationale**: This now covers only the post-selection handoff. If the timeout expires before Gorilla starts the client upgrade, the proxy returns `connect timed out after selecting worker`. If the timeout is hit during Gorilla's handshake write, the proxy logs and cleans up server-side, then closes the connection. An actual selected-worker/backend failure returns `selected worker unavailable`.
+- **Rationale**: This is a per-attempt ceiling for the post-selection handoff once the proxy commits to a specific worker. The first selected-worker handoff gets the full `PROXY_CONNECT_TIMEOUT`. During reselection, the effective timeout for a later attempt is `min(PROXY_CONNECT_TIMEOUT, remaining PROXY_WORKER_SELECTION_TIMEOUT)`. Backend dial timeout is terminal and returns `connect timed out after selecting worker`; it does not trigger reselection. If the timeout is hit during Gorilla's handshake write, the proxy logs and cleans up server-side, then closes the connection.
 
 ### 10. HTTP ReadHeaderTimeout
 - **Purpose**: Server-side deadline for reading request headers before the handler runs.

--- a/docs/proxy-connect-contract.md
+++ b/docs/proxy-connect-contract.md
@@ -64,6 +64,7 @@ Reason:
 - this is the main user-facing queue timeout
 - if all matching workers are busy, the proxy should wait for a worker instead of failing immediately
 - clients care most about how long they wait for capacity
+- the proxy may also spend this budget retrying after fast selected-worker failures before a usable handoff exists
 
 This timeout is the answer to the question: "How long will the proxy wait for a worker to become available?"
 
@@ -115,25 +116,31 @@ Stable client-facing messages in this phase include:
 `worker selection timed out` means:
 
 - the proxy kept retrying for an eligible worker
-- no worker became available before `PROXY_WORKER_SELECTION_TIMEOUT` expired
+- no usable worker became available before `PROXY_WORKER_SELECTION_TIMEOUT` expired
 
 This is deliberate. The proxy does not currently expose a fail-fast public error like `no available workers`. In the current retrying model, the real terminal client-visible failure is timeout, not an instantaneous "none available right now" signal.
 
 `connect timed out after selecting worker` means:
 
 - the proxy already selected a worker
-- the remaining handoff did not finish before `PROXY_CONNECT_TIMEOUT` expired
+- the remaining handoff did not finish before the active post-selection timeout expired
 
 This covers post-selection timeout conditions such as:
 
 - backend dial timeout
 - connect budget already exhausted before client upgrade starts
+- a later selected-worker attempt during reselection inheriting only the remaining `PROXY_WORKER_SELECTION_TIMEOUT` budget
+
+`PROXY_CONNECT_TIMEOUT` is a per-attempt ceiling, not extra time added on top of the selection phase. The first selected-worker handoff keeps the full `PROXY_CONNECT_TIMEOUT`. During reselection, the effective timeout for a later handoff attempt is `min(PROXY_CONNECT_TIMEOUT, remaining PROXY_WORKER_SELECTION_TIMEOUT)`.
 
 `selected worker unavailable` means:
 
-- the proxy selected a worker
+- the proxy saw a fast selected-worker failure
 - the failure was not classified as a timeout
-- the selected worker or its endpoint appears invalid, unreachable, or otherwise failed during the backend connection phase
+- the selected worker or its endpoint appears invalid, unreachable, or otherwise failed before a usable handoff completed
+- the proxy could not finish selection and handoff with another worker before the selection budget expired
+
+Fast retry-path rollback runs in the background so Redis bookkeeping cannot delay reselection. This can leave `allocated_sessions` temporarily inflated until rollback completes, which is an accepted internal tradeoff to preserve the public timeout contract.
 
 ### Errors During `Upgrade()`
 
@@ -172,6 +179,14 @@ This is a deliberate tradeoff. It duplicates a small part of Gorilla's behavior,
 
 Worker selection increments Redis counters during selection. That means the proxy must roll those counters back if setup fails later.
 
+The proxy intentionally keeps three different session counters:
+
+- `cluster:active_connections`: current live or still-pending sessions on the worker
+- `cluster:allocated_sessions`: optimistic lifetime budget already reserved by selection
+- `cluster:successful_sessions`: committed successful handoffs that completed proxy setup
+
+That split is deliberate. `allocated_sessions` may be temporarily inflated while async rollback catches up, but worker drain decisions must still follow `successful_sessions` so a failed handoff cannot drain a healthy worker one session early.
+
 Cleanup work uses a detached bookkeeping context instead of the request context.
 
 Reason:
@@ -189,7 +204,8 @@ The current contract intentionally does not do the following:
 - guarantee JSON after Gorilla has started the client upgrade
 - provide a public fail-fast `no available workers` error while selection is retry-based
 - blackhole or blacklist workers automatically in the proxy when a selected worker fails
-- retry different workers after a selected worker has already been chosen
+- retry different workers after backend dial has already timed out
+- retry different workers once the client upgrade path has already started
 
 Those behaviors would expand the public contract or change proxy semantics. They should be introduced only as explicit follow-up decisions.
 

--- a/proxy/internal/proxy/handler.go
+++ b/proxy/internal/proxy/handler.go
@@ -38,10 +38,10 @@ const (
 )
 
 type redisClient interface {
-	SelectWorker(ctx context.Context, browserType string) (redis.ServerInfo, error)
-	TriggerWorkerShutdownIfNeeded(ctx context.Context, serverInfo *redis.ServerInfo)
+	SelectWorker(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error)
+	RecordSuccessfulSessionAndTriggerShutdownIfNeeded(ctx context.Context, serverInfo *redis.ServerInfo)
 	ModifyActiveConnections(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
-	ModifyLifetimeConnections(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
+	ModifyAllocatedSessions(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
 }
 
 type wsConn interface {
@@ -83,9 +83,16 @@ func rollbackWorkerCounters(parent context.Context, rd redisClient, server *redi
 		logger.Error("Failed to roll back active connections for %s: %v", server.WorkerID(), derr)
 	}
 
-	if derr := rd.ModifyLifetimeConnections(ctx, server, -1); derr != nil {
-		logger.Error("Failed to roll back lifetime connections for %s: %v", server.WorkerID(), derr)
+	if derr := rd.ModifyAllocatedSessions(ctx, server, -1); derr != nil {
+		logger.Error("Failed to roll back allocated sessions for %s: %v", server.WorkerID(), derr)
 	}
+}
+
+func rollbackWorkerCountersAsync(parent context.Context, rd redisClient, server redis.ServerInfo) {
+	// Retry-path rollback must not consume the reselection budget. Temporary
+	// counter inflation is preferable to letting Redis bookkeeping delay the
+	// next selection attempt beyond PROXY_WORKER_SELECTION_TIMEOUT.
+	go rollbackWorkerCounters(parent, rd, &server)
 }
 
 func classifyWorkerSelectionError(err error) error {
@@ -100,6 +107,10 @@ func classifyWorkerSelectionError(err error) error {
 }
 
 func selectWorkerWithRetry(ctx context.Context, rd redisClient, browserType string) (redis.ServerInfo, error) {
+	return selectWorkerWithRetryExcluding(ctx, rd, browserType, nil)
+}
+
+func selectWorkerWithRetryExcluding(ctx context.Context, rd redisClient, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 	ticker := time.NewTicker(retryDelay)
 	defer ticker.Stop()
 
@@ -108,7 +119,7 @@ func selectWorkerWithRetry(ctx context.Context, rd redisClient, browserType stri
 			return redis.ServerInfo{}, classifyWorkerSelectionError(err)
 		}
 
-		server, err := rd.SelectWorker(ctx, browserType)
+		server, err := rd.SelectWorker(ctx, browserType, excludedWorkerIDs)
 		if err == nil {
 			return server, nil
 		}
@@ -128,6 +139,20 @@ func selectWorkerWithRetry(ctx context.Context, rd redisClient, browserType stri
 			return redis.ServerInfo{}, classifyWorkerSelectionError(ctx.Err())
 		}
 	}
+}
+
+func appendExcludedWorkerID(excludedWorkerIDs []string, workerID string) []string {
+	if workerID == "" {
+		return excludedWorkerIDs
+	}
+
+	for _, excludedWorkerID := range excludedWorkerIDs {
+		if excludedWorkerID == workerID {
+			return excludedWorkerIDs
+		}
+	}
+
+	return append(excludedWorkerIDs, workerID)
 }
 
 func defaultBackendDialerFactory(timeout time.Duration) websocketBackendDialer {
@@ -232,6 +257,22 @@ func remainingTimeout(ctx context.Context) time.Duration {
 	return timeout
 }
 
+func newConnectAttemptContext(
+	requestCtx context.Context,
+	selectionCtx context.Context,
+	connectTimeout time.Duration,
+	isRetry bool,
+) (context.Context, context.CancelFunc) {
+	// The first selected-worker handoff keeps the full connect timeout. Only
+	// retries after fast selected-worker failures are bounded by the remaining
+	// selection budget, so reselection cannot extend PROXY_WORKER_SELECTION_TIMEOUT.
+	if isRetry {
+		return newTimeoutContext(selectionCtx, connectTimeout)
+	}
+
+	return newTimeoutContext(requestCtx, connectTimeout)
+}
+
 func isTimeoutLikeError(err error) bool {
 	if err == nil {
 		return false
@@ -289,56 +330,89 @@ func proxyHandlerWithConnectionFactories(
 		selectionCtx, cancel := newTimeoutContext(r.Context(), selectionTimeout)
 		defer cancel()
 
-		server, err := selectWorkerWithRetry(selectionCtx, rd, browserType)
-		if err != nil {
-			switch {
-			case errors.Is(err, errWorkerSelectionDeadlineExceeded):
-				logger.Error(
-					"Connection from %s rejected. Worker selection timed out after %v.",
-					r.RemoteAddr,
-					selectionTimeout,
-				)
-				httputils.ErrorResponse(w, http.StatusServiceUnavailable, workerSelectionTimedOutMessage)
-			case errors.Is(err, errWorkerSelectionCanceled):
-				logger.Debug("Connection from %s canceled during worker selection.", r.RemoteAddr)
-			default:
-				logger.Error(
-					"Connection from %s rejected. An unexpected error occurred while selecting a worker: %v",
-					r.RemoteAddr,
-					err,
-				)
-				httputils.ErrorResponse(w, http.StatusInternalServerError, internalServerErrorMessage)
-			}
-			return
-		}
-
-		// Waiting for capacity is the main user-facing timeout. Once a worker is
-		// selected, start a separate handoff budget so queue wait and worker
-		// handoff failures stay distinct in the public contract.
-		refreshPreUpgradeWriteDeadline(w, cfg)
-
 		connectTimeout := proxyConnectTimeout(cfg)
-		connectCtx, cancel := newTimeoutContext(r.Context(), connectTimeout)
-		defer cancel()
+		excludedWorkerIDs := []string(nil)
+		sawSelectedWorkerFailure := false
 
-		backendURL, err := url.Parse(server.Endpoint)
-		if err != nil {
-			logger.Error("Connection from %s rejected. Worker endpoint is invalid: %v", r.RemoteAddr, err)
-			rollbackWorkerCounters(r.Context(), rd, &server)
-			httputils.ErrorResponse(w, http.StatusServiceUnavailable, selectedWorkerUnavailableMessage)
-			return
-		}
+		var (
+			server        redis.ServerInfo
+			serverConn    *websocket.Conn
+			connectCtx    context.Context
+			connectCancel context.CancelFunc
+		)
 
-		backendTimeout := remainingTimeout(connectCtx)
-		if backendTimeout <= 0 {
-			logger.Error("Connection from %s rejected. Connect timed out after selecting worker %s.", r.RemoteAddr, server.WorkerID())
-			rollbackWorkerCounters(r.Context(), rd, &server)
-			httputils.ErrorResponse(w, http.StatusServiceUnavailable, connectTimedOutAfterSelectingWorkerMessage)
-			return
-		}
+		for {
+			server, err := selectWorkerWithRetryExcluding(selectionCtx, rd, browserType, excludedWorkerIDs)
+			if err != nil {
+				switch {
+				case errors.Is(err, errWorkerSelectionDeadlineExceeded):
+					if sawSelectedWorkerFailure {
+						logger.Error(
+							"Connection from %s rejected. Selection budget expired after selected worker failures over %v.",
+							r.RemoteAddr,
+							selectionTimeout,
+						)
+						httputils.ErrorResponse(w, http.StatusServiceUnavailable, selectedWorkerUnavailableMessage)
+						return
+					}
 
-		serverConn, _, err := dialerFactory(backendTimeout).DialContext(connectCtx, backendURL.String(), nil)
-		if err != nil {
+					logger.Error(
+						"Connection from %s rejected. Worker selection timed out after %v.",
+						r.RemoteAddr,
+						selectionTimeout,
+					)
+					httputils.ErrorResponse(w, http.StatusServiceUnavailable, workerSelectionTimedOutMessage)
+				case errors.Is(err, errWorkerSelectionCanceled):
+					logger.Debug("Connection from %s canceled during worker selection.", r.RemoteAddr)
+				default:
+					logger.Error(
+						"Connection from %s rejected. An unexpected error occurred while selecting a worker: %v",
+						r.RemoteAddr,
+						err,
+					)
+					httputils.ErrorResponse(w, http.StatusInternalServerError, internalServerErrorMessage)
+				}
+				return
+			}
+
+			// Waiting for capacity is the main user-facing timeout. The first
+			// selected-worker handoff keeps the full connect timeout. Later retry
+			// attempts are capped by the remaining selection budget so reselection
+			// cannot extend PROXY_WORKER_SELECTION_TIMEOUT.
+			refreshPreUpgradeWriteDeadline(w, cfg)
+
+			connectCtx, connectCancel = newConnectAttemptContext(
+				r.Context(),
+				selectionCtx,
+				connectTimeout,
+				sawSelectedWorkerFailure,
+			)
+
+			backendURL, parseErr := url.Parse(server.Endpoint)
+			if parseErr != nil {
+				connectCancel()
+				logger.Error("Connection from %s rejected. Worker endpoint for %s is invalid: %v", r.RemoteAddr, server.WorkerID(), parseErr)
+				rollbackWorkerCountersAsync(r.Context(), rd, server)
+				excludedWorkerIDs = appendExcludedWorkerID(excludedWorkerIDs, server.WorkerID())
+				sawSelectedWorkerFailure = true
+				continue
+			}
+
+			backendTimeout := remainingTimeout(connectCtx)
+			if backendTimeout <= 0 {
+				connectCancel()
+				logger.Error("Connection from %s rejected. Connect timed out after selecting worker %s.", r.RemoteAddr, server.WorkerID())
+				rollbackWorkerCounters(r.Context(), rd, &server)
+				httputils.ErrorResponse(w, http.StatusServiceUnavailable, connectTimedOutAfterSelectingWorkerMessage)
+				return
+			}
+
+			serverConn, _, err = dialerFactory(backendTimeout).DialContext(connectCtx, backendURL.String(), nil)
+			if err == nil {
+				break
+			}
+
+			connectCancel()
 			if isTimeoutLikeError(err) {
 				logger.Error("Connection from %s rejected. Connect timed out while dialing selected worker %s.", r.RemoteAddr, server.WorkerID())
 				rollbackWorkerCounters(r.Context(), rd, &server)
@@ -352,11 +426,12 @@ func proxyHandlerWithConnectionFactories(
 			}
 
 			logger.Error("Connection from %s rejected. Failed to connect to selected worker %s: %v", r.RemoteAddr, server.WorkerID(), err)
-			rollbackWorkerCounters(r.Context(), rd, &server)
-			httputils.ErrorResponse(w, http.StatusServiceUnavailable, selectedWorkerUnavailableMessage)
-			return
+			rollbackWorkerCountersAsync(r.Context(), rd, server)
+			excludedWorkerIDs = appendExcludedWorkerID(excludedWorkerIDs, server.WorkerID())
+			sawSelectedWorkerFailure = true
 		}
 		defer serverConn.Close()
+		defer connectCancel()
 
 		clientHandshakeTimeout := remainingTimeout(connectCtx)
 		if clientHandshakeTimeout <= 0 {
@@ -388,7 +463,11 @@ func proxyHandlerWithConnectionFactories(
 		go func() {
 			ctx, cancel := newBookkeepingContext(r.Context())
 			defer cancel()
-			rd.TriggerWorkerShutdownIfNeeded(ctx, &server)
+			// Shutdown must be driven by committed successful sessions, not the
+			// optimistic selector allocation counter. Async rollback can leave the
+			// allocation counter temporarily inflated, but it must not drain a
+			// healthy worker one session early.
+			rd.RecordSuccessfulSessionAndTriggerShutdownIfNeeded(ctx, &server)
 		}()
 
 		atomic.AddInt64(&activeConnections, 1)
@@ -397,7 +476,7 @@ func proxyHandlerWithConnectionFactories(
 		defer func() {
 			atomic.AddInt64(&activeConnections, -1)
 
-			// `rd.SelectWorker` is increasing this counter during selection process
+			// `rd.SelectWorker` reserves one active slot during selection.
 			ctx, cancel := newBookkeepingContext(r.Context())
 			defer cancel()
 			if err := rd.ModifyActiveConnections(ctx, &server, -1); err != nil {

--- a/proxy/internal/proxy/handler_test.go
+++ b/proxy/internal/proxy/handler_test.go
@@ -31,22 +31,34 @@ func init() {
 const validWebSocketKey = "dGhlIHNhbXBsZSBub25jZQ=="
 
 type fakeRedisClient struct {
-	selectWorkerFunc              func(ctx context.Context, browserType string) (redis.ServerInfo, error)
-	triggerWorkerShutdownFunc     func(ctx context.Context, serverInfo *redis.ServerInfo)
-	modifyActiveConnectionsFunc   func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
-	modifyLifetimeConnectionsFunc func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
+	selectWorkerFunc                              func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error)
+	recordSuccessfulSessionAndTriggerShutdownFunc func(ctx context.Context, serverInfo *redis.ServerInfo)
+	modifyActiveConnectionsFunc                   func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
+	modifyAllocatedSessionsFunc                   func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error
 }
 
-func (f *fakeRedisClient) SelectWorker(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+func (f *fakeRedisClient) SelectWorker(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 	if f.selectWorkerFunc != nil {
-		return f.selectWorkerFunc(ctx, browserType)
+		server, err := f.selectWorkerFunc(ctx, browserType, excludedWorkerIDs)
+		if err != nil {
+			return redis.ServerInfo{}, err
+		}
+
+		for _, excludedWorkerID := range excludedWorkerIDs {
+			if server.WorkerID() == excludedWorkerID {
+				return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
+			}
+		}
+
+		return server, nil
 	}
+
 	return redis.ServerInfo{}, nil
 }
 
-func (f *fakeRedisClient) TriggerWorkerShutdownIfNeeded(ctx context.Context, serverInfo *redis.ServerInfo) {
-	if f.triggerWorkerShutdownFunc != nil {
-		f.triggerWorkerShutdownFunc(ctx, serverInfo)
+func (f *fakeRedisClient) RecordSuccessfulSessionAndTriggerShutdownIfNeeded(ctx context.Context, serverInfo *redis.ServerInfo) {
+	if f.recordSuccessfulSessionAndTriggerShutdownFunc != nil {
+		f.recordSuccessfulSessionAndTriggerShutdownFunc(ctx, serverInfo)
 	}
 }
 
@@ -57,9 +69,9 @@ func (f *fakeRedisClient) ModifyActiveConnections(ctx context.Context, serverInf
 	return nil
 }
 
-func (f *fakeRedisClient) ModifyLifetimeConnections(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
-	if f.modifyLifetimeConnectionsFunc != nil {
-		return f.modifyLifetimeConnectionsFunc(ctx, serverInfo, delta)
+func (f *fakeRedisClient) ModifyAllocatedSessions(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+	if f.modifyAllocatedSessionsFunc != nil {
+		return f.modifyAllocatedSessionsFunc(ctx, serverInfo, delta)
 	}
 	return nil
 }
@@ -67,6 +79,7 @@ func (f *fakeRedisClient) ModifyLifetimeConnections(ctx context.Context, serverI
 func newTestConfig() *config.Config {
 	return &config.Config{
 		DefaultBrowserType:          "chromium",
+		SelectorFreshnessTimeout:    60,
 		ProxyReadHeaderTimeout:      1,
 		ProxyWorkerSelectionTimeout: 1,
 		ProxyConnectTimeout:         1,
@@ -86,8 +99,8 @@ func TestProxyHandler_InvalidBrowserType(t *testing.T) {
 
 func TestProxyHandler_NonRootPathReturnsNotFound(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
-			t.Fatalf("selectWorker should not be called, got browserType %s", browserType)
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			t.Fatalf("SelectWorker should not be called, got browserType %s", browserType)
 			return redis.ServerInfo{}, nil
 		},
 	}
@@ -108,7 +121,7 @@ func TestProxyHandler_DefaultBrowserTypeIsUsedWhenMissing(t *testing.T) {
 
 	browserCh := make(chan string, 1)
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			browserCh <- browserType
 			return redis.ServerInfo{}, errors.New("boom")
 		},
@@ -154,7 +167,7 @@ func TestProxyHandler_AllowsKnownBrowserQueryValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			browserCh := make(chan string, 1)
 			fake := &fakeRedisClient{
-				selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+				selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 					browserCh <- browserType
 					return redis.ServerInfo{}, errors.New("boom")
 				},
@@ -222,7 +235,7 @@ func TestProxyHandler_NonWebSocketRequest(t *testing.T) {
 
 func TestProxyHandler_HandshakePreflightRejectsNonGETMethod(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			t.Fatal("SelectWorker should not be called for invalid method")
 			return redis.ServerInfo{}, nil
 		},
@@ -247,7 +260,7 @@ func TestProxyHandler_HandshakePreflightRejectsNonGETMethod(t *testing.T) {
 
 func TestProxyHandler_HandshakePreflightRejectsUnsupportedVersion(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			t.Fatal("SelectWorker should not be called for unsupported version")
 			return redis.ServerInfo{}, nil
 		},
@@ -272,7 +285,7 @@ func TestProxyHandler_HandshakePreflightRejectsUnsupportedVersion(t *testing.T) 
 
 func TestProxyHandler_HandshakePreflightRejectsInvalidKey(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			t.Fatal("SelectWorker should not be called for invalid key")
 			return redis.ServerInfo{}, nil
 		},
@@ -368,7 +381,7 @@ func TestValidateClientHandshake_ParallelsGorillaForMalformedRequests(t *testing
 
 func TestProxyHandler_WorkerSelectionTimeoutReturnsStructuredError(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
 		},
 	}
@@ -385,7 +398,7 @@ func TestProxyHandler_WorkerSelectionTimeoutReturnsStructuredError(t *testing.T)
 
 func TestProxyHandler_CanceledSelectionDoesNotWriteStructuredResponse(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			t.Fatal("SelectWorker should not be called for an already canceled request")
 			return redis.ServerInfo{}, nil
 		},
@@ -412,7 +425,7 @@ func TestProxyHandler_CanceledSelectionDoesNotWriteStructuredResponse(t *testing
 func TestProxyHandler_SelectWorkerUnexpectedError(t *testing.T) {
 	expectedErr := errors.New("boom")
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{}, expectedErr
 		},
 	}
@@ -433,7 +446,7 @@ func TestProxyHandler_SelectWorkerUnexpectedError(t *testing.T) {
 func TestSelectWorkerWithRetryRetriesUntilSuccess(t *testing.T) {
 	attempts := 0
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			attempts++
 			if attempts < 2 {
 				return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
@@ -461,7 +474,7 @@ func TestSelectWorkerWithRetryRetriesUntilSuccess(t *testing.T) {
 
 func TestSelectWorkerWithRetryTimeout(t *testing.T) {
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
 		},
 	}
@@ -484,7 +497,7 @@ func TestSelectWorkerWithRetryTimeout(t *testing.T) {
 func TestSelectWorkerWithRetryCanceledContext(t *testing.T) {
 	calls := int32(0)
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			atomic.AddInt32(&calls, 1)
 			return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
 		},
@@ -506,7 +519,7 @@ func TestSelectWorkerWithRetryCanceledContext(t *testing.T) {
 func TestSelectWorkerWithRetryUnexpectedError(t *testing.T) {
 	expectedErr := errors.New("boom")
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{}, expectedErr
 		},
 	}
@@ -517,6 +530,33 @@ func TestSelectWorkerWithRetryUnexpectedError(t *testing.T) {
 	_, err := selectWorkerWithRetry(ctx, fake, "chromium")
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected unexpected selector error %v, got %v", expectedErr, err)
+	}
+}
+
+func TestSelectWorkerWithRetryPassesExcludedWorkerIDs(t *testing.T) {
+	expectedExcludedWorkerIDs := []string{"chromium:worker-1"}
+	fake := &fakeRedisClient{
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			if browserType != "chromium" {
+				t.Fatalf("expected browser type chromium, got %s", browserType)
+			}
+			if len(excludedWorkerIDs) != len(expectedExcludedWorkerIDs) || excludedWorkerIDs[0] != expectedExcludedWorkerIDs[0] {
+				t.Fatalf("expected excluded worker IDs %v, got %v", expectedExcludedWorkerIDs, excludedWorkerIDs)
+			}
+			return redis.ServerInfo{ID: "worker-2"}, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	server, err := selectWorkerWithRetryExcluding(ctx, fake, "chromium", expectedExcludedWorkerIDs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if server.ID != "worker-2" {
+		t.Fatalf("expected worker ID worker-2, got %q", server.ID)
 	}
 }
 
@@ -558,10 +598,10 @@ func TestProxyHandler_SuccessfulConnectionLifecycle(t *testing.T) {
 	modifyCalls := make(chan int64, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
-		triggerWorkerShutdownFunc: func(ctx context.Context, serverInfo *redis.ServerInfo) {
+		recordSuccessfulSessionAndTriggerShutdownFunc: func(ctx context.Context, serverInfo *redis.ServerInfo) {
 			shutdownCalled <- struct{}{}
 		},
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
@@ -604,7 +644,7 @@ func TestProxyHandler_SuccessfulConnectionLifecycle(t *testing.T) {
 	select {
 	case <-shutdownCalled:
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected TriggerWorkerShutdownIfNeeded to be called")
+		t.Fatal("expected RecordSuccessfulSessionAndTriggerShutdownIfNeeded to be called")
 	}
 
 	select {
@@ -653,7 +693,7 @@ func TestProxyHandler_SuccessfulConnectionCleanupUsesDetachedBookkeepingContext(
 	modifyCalls := make(chan redisModifyCall, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
@@ -740,10 +780,10 @@ func TestProxyHandler_TriggerWorkerShutdownUsesDetachedBookkeepingContext(t *tes
 	triggerCtxErr := make(chan error, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
-		triggerWorkerShutdownFunc: func(ctx context.Context, serverInfo *redis.ServerInfo) {
+		recordSuccessfulSessionAndTriggerShutdownFunc: func(ctx context.Context, serverInfo *redis.ServerInfo) {
 			time.Sleep(1200 * time.Millisecond)
 			triggerCtxErr <- ctx.Err()
 		},
@@ -782,7 +822,7 @@ func TestProxyHandler_TriggerWorkerShutdownUsesDetachedBookkeepingContext(t *tes
 			t.Fatalf("expected detached bookkeeping context, got %v", err)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("expected TriggerWorkerShutdownIfNeeded to be called")
+		t.Fatal("expected RecordSuccessfulSessionAndTriggerShutdownIfNeeded to be called")
 	}
 }
 
@@ -792,17 +832,17 @@ func TestProxyHandler_BackendDialFailure(t *testing.T) {
 	modifyLifetimeCalls := make(chan int64, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: "ws://127.0.0.1:1"}, nil
 		},
-		triggerWorkerShutdownFunc: func(ctx context.Context, serverInfo *redis.ServerInfo) {
+		recordSuccessfulSessionAndTriggerShutdownFunc: func(ctx context.Context, serverInfo *redis.ServerInfo) {
 			shutdownCalled <- struct{}{}
 		},
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
 			modifyActiveCalls <- delta
 			return nil
 		},
-		modifyLifetimeConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
 			modifyLifetimeCalls <- delta
 			return nil
 		},
@@ -821,11 +861,11 @@ func TestProxyHandler_BackendDialFailure(t *testing.T) {
 
 	assertJSONErrorResponse(t, resp, http.StatusServiceUnavailable, selectedWorkerUnavailableMessage)
 
-	// TriggerWorkerShutdownIfNeeded should NOT be called on backend dial failure
+	// RecordSuccessfulSessionAndTriggerShutdownIfNeeded should NOT be called on backend dial failure
 	// because the connection never succeeded and counters will be rolled back
 	select {
 	case <-shutdownCalled:
-		t.Fatal("TriggerWorkerShutdownIfNeeded should not be called when backend dial fails")
+		t.Fatal("RecordSuccessfulSessionAndTriggerShutdownIfNeeded should not be called when backend dial fails")
 	case <-time.After(100 * time.Millisecond):
 		// Expected: shutdown should not be triggered
 	}
@@ -842,19 +882,19 @@ func TestProxyHandler_BackendDialFailure(t *testing.T) {
 	select {
 	case delta := <-modifyLifetimeCalls:
 		if delta != -1 {
-			t.Fatalf("expected ModifyLifetimeConnections delta -1, got %d", delta)
+			t.Fatalf("expected ModifyAllocatedSessions delta -1, got %d", delta)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected ModifyLifetimeConnections rollback")
+		t.Fatal("expected ModifyAllocatedSessions rollback")
 	}
 }
 
 func TestProxyHandler_BackendDialFailureRollbackUsesDetachedBookkeepingContext(t *testing.T) {
 	activeRollback := make(chan redisModifyCall, 1)
-	lifetimeRollback := make(chan redisModifyCall, 1)
+	allocatedRollback := make(chan redisModifyCall, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{
 				ID:          "worker-1",
 				BrowserType: "chromium",
@@ -865,8 +905,8 @@ func TestProxyHandler_BackendDialFailureRollbackUsesDetachedBookkeepingContext(t
 			activeRollback <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
 			return nil
 		},
-		modifyLifetimeConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
-			lifetimeRollback <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			allocatedRollback <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
 			return nil
 		},
 	}
@@ -907,15 +947,104 @@ func TestProxyHandler_BackendDialFailureRollbackUsesDetachedBookkeepingContext(t
 	}
 
 	select {
-	case call := <-lifetimeRollback:
+	case call := <-allocatedRollback:
 		if call.delta != -1 {
-			t.Fatalf("expected ModifyLifetimeConnections delta -1, got %d", call.delta)
+			t.Fatalf("expected ModifyAllocatedSessions delta -1, got %d", call.delta)
 		}
 		if call.ctxErr != nil {
-			t.Fatalf("expected detached bookkeeping context for lifetime rollback, got %v", call.ctxErr)
+			t.Fatalf("expected detached bookkeeping context for allocated rollback, got %v", call.ctxErr)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected ModifyLifetimeConnections rollback")
+		t.Fatal("expected ModifyAllocatedSessions rollback")
+	}
+}
+
+func TestProxyHandler_ReselectsAfterFastSelectedWorkerFailure(t *testing.T) {
+	backendUpgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := backendUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("backend upgrade failed: %v", err)
+		}
+		defer conn.Close()
+
+		for {
+			msgType, payload, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := conn.WriteMessage(msgType, payload); err != nil {
+				return
+			}
+		}
+	}))
+	defer backend.Close()
+
+	workerEndpoint := "ws" + strings.TrimPrefix(backend.URL, "http")
+	var (
+		mu             sync.Mutex
+		selectionCalls [][]string
+	)
+
+	fake := &fakeRedisClient{
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			mu.Lock()
+			selectionCalls = append(selectionCalls, append([]string(nil), excludedWorkerIDs...))
+			mu.Unlock()
+
+			if len(excludedWorkerIDs) == 0 {
+				return redis.ServerInfo{
+					ID:          "worker-1",
+					BrowserType: "chromium",
+					Endpoint:    "ws://127.0.0.1:1/playwright",
+				}, nil
+			}
+
+			if len(excludedWorkerIDs) == 1 && excludedWorkerIDs[0] == "chromium:worker-1" {
+				return redis.ServerInfo{
+					ID:          "worker-2",
+					BrowserType: "chromium",
+					Endpoint:    workerEndpoint,
+				}, nil
+			}
+
+			t.Fatalf("unexpected excluded worker IDs: %v", excludedWorkerIDs)
+			return redis.ServerInfo{}, nil
+		},
+	}
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(proxyHandler(fake, newTestConfig())))
+	defer proxyServer.Close()
+
+	proxyURL := "ws" + strings.TrimPrefix(proxyServer.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(proxyURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial proxy: %v", err)
+	}
+	defer clientConn.Close()
+
+	if err := clientConn.WriteMessage(websocket.TextMessage, []byte("hello")); err != nil {
+		t.Fatalf("failed to write message: %v", err)
+	}
+
+	_, payload, err := clientConn.ReadMessage()
+	if err != nil {
+		t.Fatalf("failed to read echoed message: %v", err)
+	}
+	if string(payload) != "hello" {
+		t.Fatalf("expected echoed payload hello, got %q", payload)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(selectionCalls) < 2 {
+		t.Fatalf("expected reselection after fast selected-worker failure, got %d selection calls", len(selectionCalls))
+	}
+	if len(selectionCalls[0]) != 0 {
+		t.Fatalf("expected first selection to have no exclusions, got %v", selectionCalls[0])
+	}
+	if len(selectionCalls[1]) != 1 || selectionCalls[1][0] != "chromium:worker-1" {
+		t.Fatalf("expected second selection to exclude chromium:worker-1, got %v", selectionCalls[1])
 	}
 }
 
@@ -938,17 +1067,17 @@ func TestProxyHandler_WebSocketUpgradeFailureRollsBackCounters(t *testing.T) {
 	workerEndpoint := "ws" + strings.TrimPrefix(backend.URL, "http")
 
 	activeRollbacks := make(chan int64, 1)
-	lifetimeRollbacks := make(chan int64, 1)
+	allocatedRollbacks := make(chan int64, 1)
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
 			activeRollbacks <- delta
 			return nil
 		},
-		modifyLifetimeConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
-			lifetimeRollbacks <- delta
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			allocatedRollbacks <- delta
 			return nil
 		},
 	}
@@ -966,8 +1095,8 @@ func TestProxyHandler_WebSocketUpgradeFailureRollsBackCounters(t *testing.T) {
 
 	assertPlainTextStatusResponse(t, resp, http.StatusInternalServerError)
 
-	if got := atomic.LoadInt64(&activeConnections); got != 0 {
-		t.Fatalf("expected activeConnections to remain 0, got %d", got)
+	if got := atomic.LoadInt64(&activeConnections); got > 0 {
+		t.Fatalf("expected activeConnections not to increase, got %d", got)
 	}
 
 	select {
@@ -980,12 +1109,12 @@ func TestProxyHandler_WebSocketUpgradeFailureRollsBackCounters(t *testing.T) {
 	}
 
 	select {
-	case delta := <-lifetimeRollbacks:
+	case delta := <-allocatedRollbacks:
 		if delta != -1 {
-			t.Fatalf("expected ModifyLifetimeConnections rollback delta -1, got %d", delta)
+			t.Fatalf("expected ModifyAllocatedSessions rollback delta -1, got %d", delta)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected ModifyLifetimeConnections rollback")
+		t.Fatal("expected ModifyAllocatedSessions rollback")
 	}
 }
 
@@ -1019,7 +1148,7 @@ func TestProxyHandler_ModifyActiveConnectionsErrorIsIgnored(t *testing.T) {
 
 	modifyCalls := make(chan int64, 1)
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
@@ -1061,7 +1190,7 @@ func TestProxyHandler_ModifyActiveConnectionsErrorIsIgnored(t *testing.T) {
 func TestProxyHandler_BackendDialHonorsRequestDeadline(t *testing.T) {
 	dialStarted := make(chan struct{}, 1)
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{
 				ID:          "worker-1",
 				BrowserType: "chromium",
@@ -1071,7 +1200,7 @@ func TestProxyHandler_BackendDialHonorsRequestDeadline(t *testing.T) {
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
 			return nil
 		},
-		modifyLifetimeConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
 			return nil
 		},
 	}
@@ -1138,9 +1267,11 @@ func TestProxyHandler_BackendDialHandshakeTimeoutReturnsConnectTimeout(t *testin
 	}()
 
 	activeRollback := make(chan redisModifyCall, 1)
-	lifetimeRollback := make(chan redisModifyCall, 1)
+	allocatedRollback := make(chan redisModifyCall, 1)
+	selectCalls := int32(0)
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			atomic.AddInt32(&selectCalls, 1)
 			return redis.ServerInfo{
 				ID:          "worker-1",
 				BrowserType: "chromium",
@@ -1151,8 +1282,8 @@ func TestProxyHandler_BackendDialHandshakeTimeoutReturnsConnectTimeout(t *testin
 			activeRollback <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
 			return nil
 		},
-		modifyLifetimeConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
-			lifetimeRollback <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			allocatedRollback <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
 			return nil
 		},
 	}
@@ -1184,6 +1315,9 @@ func TestProxyHandler_BackendDialHandshakeTimeoutReturnsConnectTimeout(t *testin
 	if elapsed < 900*time.Millisecond {
 		t.Fatalf("expected backend handshake timeout near configured connect timeout, got %v", elapsed)
 	}
+	if got := atomic.LoadInt32(&selectCalls); got != 1 {
+		t.Fatalf("expected backend dial timeout not to trigger reselection, got %d selection calls", got)
+	}
 
 	select {
 	case call := <-activeRollback:
@@ -1198,16 +1332,301 @@ func TestProxyHandler_BackendDialHandshakeTimeoutReturnsConnectTimeout(t *testin
 	}
 
 	select {
-	case call := <-lifetimeRollback:
+	case call := <-allocatedRollback:
 		if call.delta != -1 {
-			t.Fatalf("expected ModifyLifetimeConnections delta -1, got %d", call.delta)
+			t.Fatalf("expected ModifyAllocatedSessions delta -1, got %d", call.delta)
 		}
 		if call.ctxErr != nil {
-			t.Fatalf("expected detached bookkeeping context for lifetime rollback, got %v", call.ctxErr)
+			t.Fatalf("expected detached bookkeeping context for allocated rollback, got %v", call.ctxErr)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected ModifyLifetimeConnections rollback")
+		t.Fatal("expected ModifyAllocatedSessions rollback")
 	}
+}
+
+func TestProxyHandler_FirstHandoffKeepsFullConnectTimeout(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer listener.Close()
+
+	acceptedConn := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		acceptedConn <- conn
+	}()
+
+	var stalledConn net.Conn
+	defer func() {
+		if stalledConn != nil {
+			_ = stalledConn.Close()
+		}
+	}()
+
+	cfg := newTestConfig()
+	cfg.ProxyWorkerSelectionTimeout = 1
+	cfg.ProxyConnectTimeout = 2
+
+	selectCalls := int32(0)
+	fake := &fakeRedisClient{
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			atomic.AddInt32(&selectCalls, 1)
+			if len(excludedWorkerIDs) != 0 {
+				t.Fatalf("expected first handoff not to exclude any workers, got %v", excludedWorkerIDs)
+			}
+			return redis.ServerInfo{
+				ID:          "worker-1",
+				BrowserType: "chromium",
+				Endpoint:    "ws://" + listener.Addr().String() + "/playwright",
+			}, nil
+		},
+		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			return nil
+		},
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			return nil
+		},
+	}
+
+	handler := proxyHandler(fake, cfg)
+
+	req := newWebSocketUpgradeRequest(http.MethodGet)
+	resp := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(resp, req)
+	elapsed := time.Since(start)
+
+	select {
+	case stalledConn = <-acceptedConn:
+	case err := <-acceptErr:
+		t.Fatalf("failed to accept backend dial: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected backend dial to reach stalled listener")
+	}
+
+	assertJSONErrorResponse(t, resp, http.StatusServiceUnavailable, connectTimedOutAfterSelectingWorkerMessage)
+	if elapsed < 1900*time.Millisecond {
+		t.Fatalf("expected first handoff to keep the full connect timeout, got %v", elapsed)
+	}
+	if elapsed > 2600*time.Millisecond {
+		t.Fatalf("expected first handoff timeout near configured connect timeout, got %v", elapsed)
+	}
+	if got := atomic.LoadInt32(&selectCalls); got != 1 {
+		t.Fatalf("expected no reselection on first handoff timeout, got %d selection calls", got)
+	}
+}
+
+func TestProxyHandler_ReselectionStaysWithinSelectionTimeout(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.ProxyWorkerSelectionTimeout = 1
+	cfg.ProxyConnectTimeout = 1
+
+	var (
+		mu             sync.Mutex
+		selectionCalls [][]string
+		dialTimeouts   []time.Duration
+	)
+
+	fake := &fakeRedisClient{
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			mu.Lock()
+			selectionCalls = append(selectionCalls, append([]string(nil), excludedWorkerIDs...))
+			mu.Unlock()
+
+			switch len(excludedWorkerIDs) {
+			case 0:
+				return redis.ServerInfo{
+					ID:          "worker-1",
+					BrowserType: "chromium",
+					Endpoint:    "ws://worker-1.invalid/playwright",
+				}, nil
+			case 1:
+				if excludedWorkerIDs[0] != "chromium:worker-1" {
+					t.Fatalf("expected chromium:worker-1 to be excluded, got %v", excludedWorkerIDs)
+				}
+				return redis.ServerInfo{
+					ID:          "worker-2",
+					BrowserType: "chromium",
+					Endpoint:    "ws://worker-2.invalid/playwright",
+				}, nil
+			default:
+				t.Fatalf("unexpected exclusions: %v", excludedWorkerIDs)
+				return redis.ServerInfo{}, nil
+			}
+		},
+		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			return nil
+		},
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			return nil
+		},
+	}
+
+	handler := proxyHandlerWithBackendDialer(fake, cfg, func(timeout time.Duration) websocketBackendDialer {
+		mu.Lock()
+		dialTimeouts = append(dialTimeouts, timeout)
+		mu.Unlock()
+
+		return &stubBackendDialer{
+			dialContextFunc: func(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+				switch urlStr {
+				case "ws://worker-1.invalid/playwright":
+					time.Sleep(700 * time.Millisecond)
+					return nil, nil, errors.New("selected worker failed fast")
+				case "ws://worker-2.invalid/playwright":
+					<-ctx.Done()
+					return nil, nil, ctx.Err()
+				default:
+					t.Fatalf("unexpected backend URL %q", urlStr)
+					return nil, nil, nil
+				}
+			},
+		}
+	})
+
+	req := newWebSocketUpgradeRequest(http.MethodGet)
+	resp := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(resp, req)
+	elapsed := time.Since(start)
+
+	assertJSONErrorResponse(t, resp, http.StatusServiceUnavailable, connectTimedOutAfterSelectingWorkerMessage)
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("expected reselection flow to consume most of the selection budget, got %v", elapsed)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("expected reselection to stay within selection timeout budget, got %v", elapsed)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(selectionCalls) != 2 {
+		t.Fatalf("expected two selection attempts, got %d", len(selectionCalls))
+	}
+	if len(selectionCalls[0]) != 0 {
+		t.Fatalf("expected first selection attempt to have no exclusions, got %v", selectionCalls[0])
+	}
+	if len(selectionCalls[1]) != 1 || selectionCalls[1][0] != "chromium:worker-1" {
+		t.Fatalf("expected second selection to exclude chromium:worker-1, got %v", selectionCalls[1])
+	}
+	if len(dialTimeouts) != 2 {
+		t.Fatalf("expected two backend dial attempts, got %d", len(dialTimeouts))
+	}
+	if dialTimeouts[0] < 900*time.Millisecond {
+		t.Fatalf("expected first dial timeout near the full connect timeout, got %v", dialTimeouts[0])
+	}
+	if dialTimeouts[1] <= 0 {
+		t.Fatalf("expected second dial timeout to remain positive, got %v", dialTimeouts[1])
+	}
+	if dialTimeouts[1] >= 500*time.Millisecond {
+		t.Fatalf("expected second dial timeout to be capped by the remaining selection budget, got %v", dialTimeouts[1])
+	}
+}
+
+func TestProxyHandler_ReselectionDoesNotWaitForRetryRollback(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.ProxyWorkerSelectionTimeout = 1
+	cfg.ProxyConnectTimeout = 1
+
+	selectionCalled := make(chan time.Time, 2)
+	rollbackStarted := make(chan struct{}, 1)
+	rollbackRelease := make(chan struct{})
+
+	fake := &fakeRedisClient{
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
+			selectionCalled <- time.Now()
+
+			switch len(excludedWorkerIDs) {
+			case 0:
+				return redis.ServerInfo{
+					ID:          "worker-1",
+					BrowserType: "chromium",
+					Endpoint:    "ws://worker-1.invalid/playwright",
+				}, nil
+			case 1:
+				if excludedWorkerIDs[0] != "chromium:worker-1" {
+					t.Fatalf("expected chromium:worker-1 to be excluded, got %v", excludedWorkerIDs)
+				}
+				return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
+			default:
+				t.Fatalf("unexpected exclusions: %v", excludedWorkerIDs)
+				return redis.ServerInfo{}, nil
+			}
+		},
+		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			if delta == -1 && serverInfo.WorkerID() == "chromium:worker-1" {
+				select {
+				case rollbackStarted <- struct{}{}:
+				default:
+				}
+				<-rollbackRelease
+			}
+			return nil
+		},
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			return nil
+		},
+	}
+
+	handler := proxyHandlerWithBackendDialer(fake, cfg, func(timeout time.Duration) websocketBackendDialer {
+		return &stubBackendDialer{
+			dialContextFunc: func(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+				if urlStr != "ws://worker-1.invalid/playwright" {
+					t.Fatalf("unexpected backend URL %q", urlStr)
+				}
+				return nil, nil, errors.New("selected worker failed fast")
+			},
+		}
+	})
+
+	req := newWebSocketUpgradeRequest(http.MethodGet)
+	resp := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(resp, req)
+		close(done)
+	}()
+
+	var firstSelection time.Time
+	select {
+	case firstSelection = <-selectionCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected first selection attempt")
+	}
+
+	select {
+	case <-rollbackStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected retry rollback to start")
+	}
+
+	select {
+	case secondSelection := <-selectionCalled:
+		if secondSelection.Sub(firstSelection) > 300*time.Millisecond {
+			t.Fatalf("expected reselection to proceed without waiting for rollback, got %v", secondSelection.Sub(firstSelection))
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected reselection before rollback finished")
+	}
+
+	close(rollbackRelease)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected handler to finish after releasing rollback")
+	}
+
+	assertJSONErrorResponse(t, resp, http.StatusServiceUnavailable, selectedWorkerUnavailableMessage)
 }
 
 func TestProxyHandler_ClientUpgraderReceivesRemainingConnectTimeout(t *testing.T) {
@@ -1232,7 +1651,7 @@ func TestProxyHandler_ClientUpgraderReceivesRemainingConnectTimeout(t *testing.T
 	upgraderTimeouts := make(chan time.Duration, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
 	}
@@ -1303,18 +1722,18 @@ func TestProxyHandler_ClientUpgradeFailureRollsBackAndClosesBackendConnection(t 
 
 	workerEndpoint := "ws" + strings.TrimPrefix(backend.URL, "http")
 	activeRollbacks := make(chan redisModifyCall, 1)
-	lifetimeRollbacks := make(chan redisModifyCall, 1)
+	allocatedRollbacks := make(chan redisModifyCall, 1)
 
 	fake := &fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{ID: "worker-1", Endpoint: workerEndpoint}, nil
 		},
 		modifyActiveConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
 			activeRollbacks <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
 			return nil
 		},
-		modifyLifetimeConnectionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
-			lifetimeRollbacks <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
+		modifyAllocatedSessionsFunc: func(ctx context.Context, serverInfo *redis.ServerInfo, delta int64) error {
+			allocatedRollbacks <- redisModifyCall{delta: delta, ctxErr: ctx.Err()}
 			return nil
 		},
 	}
@@ -1364,15 +1783,15 @@ func TestProxyHandler_ClientUpgradeFailureRollsBackAndClosesBackendConnection(t 
 	}
 
 	select {
-	case call := <-lifetimeRollbacks:
+	case call := <-allocatedRollbacks:
 		if call.delta != -1 {
-			t.Fatalf("expected ModifyLifetimeConnections delta -1, got %d", call.delta)
+			t.Fatalf("expected ModifyAllocatedSessions delta -1, got %d", call.delta)
 		}
 		if call.ctxErr != nil {
-			t.Fatalf("expected detached bookkeeping context for lifetime rollback, got %v", call.ctxErr)
+			t.Fatalf("expected detached bookkeeping context for allocated rollback, got %v", call.ctxErr)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected ModifyLifetimeConnections rollback")
+		t.Fatal("expected ModifyAllocatedSessions rollback")
 	}
 
 	select {
@@ -1411,7 +1830,7 @@ func TestIsTimeoutLikeError(t *testing.T) {
 func TestProxyHandler_KeepsWorkerSelectionTimeoutRequestScopedAcrossKeepAliveRequests(t *testing.T) {
 	cfg := newTestConfig()
 	handler := http.HandlerFunc(proxyHandler(&fakeRedisClient{
-		selectWorkerFunc: func(ctx context.Context, browserType string) (redis.ServerInfo, error) {
+		selectWorkerFunc: func(ctx context.Context, browserType string, excludedWorkerIDs []string) (redis.ServerInfo, error) {
 			return redis.ServerInfo{}, redis.ErrNoAvailableWorkers
 		},
 	}, cfg))

--- a/proxy/internal/redis/client.go
+++ b/proxy/internal/redis/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"proxy/pkg/config"
 	"proxy/pkg/logger"
+	"slices"
 	"strconv"
 	"time"
 
@@ -14,8 +15,10 @@ import (
 )
 
 const (
-	activeConnectionsKey   = "cluster:active_connections"
-	lifetimeConnectionsKey = "cluster:lifetime_connections"
+	activeConnectionsKey     = "cluster:active_connections"
+	allocatedSessionsKey     = "cluster:allocated_sessions"
+	successfulSessionsKey    = "cluster:successful_sessions"
+	workerShutdownCommandFmt = "worker:cmd:%s"
 )
 
 //go:embed selector.lua
@@ -25,6 +28,8 @@ var selectorScriptSource string
 var reaperScriptSource string
 
 var ErrNoAvailableWorkers = errors.New("no available workers")
+
+const selectorResultFieldCount = 6
 
 type Client struct {
 	rd             *redis.Client
@@ -106,29 +111,32 @@ func (c *Client) GetWorkerActiveConnections(ctx context.Context, workerId string
 	return val, nil
 }
 
-func (c *Client) GetLifetimeConnections(ctx context.Context, workerId string) (int64, error) {
-	val, err := c.rd.HGet(ctx, lifetimeConnectionsKey, workerId).Int64()
+func (c *Client) GetAllocatedSessions(ctx context.Context, workerId string) (int64, error) {
+	val, err := c.rd.HGet(ctx, allocatedSessionsKey, workerId).Int64()
 	if err == redis.Nil {
 		return 0, nil
 	} else if err != nil {
-		return 0, fmt.Errorf("failed to get lifetime connections for worker %s: %w", workerId, err)
+		return 0, fmt.Errorf("failed to get allocated sessions for worker %s: %w", workerId, err)
 	}
 
 	return val, nil
 }
 
-func (c *Client) TriggerWorkerShutdownIfNeeded(ctx context.Context, serverInfo *ServerInfo) {
-	currentLifetime, err := c.GetLifetimeConnections(ctx, serverInfo.WorkerID())
+func (c *Client) RecordSuccessfulSessionAndTriggerShutdownIfNeeded(ctx context.Context, serverInfo *ServerInfo) {
+	// Shutdown must follow committed successful handoffs, not optimistic
+	// selector allocations. Async rollback can leave allocated_sessions
+	// temporarily inflated after a failed pre-upgrade handoff.
+	currentSuccessful, err := c.rd.HIncrBy(ctx, successfulSessionsKey, serverInfo.WorkerID(), 1).Result()
 	if err != nil {
-		logger.WithField("workerId", serverInfo.WorkerID()).Errorf("Could not get lifetime connections: %v", err)
+		logger.WithField("workerId", serverInfo.WorkerID()).Errorf("Failed to record successful session: %v", err)
 		return
 	}
 
-	if currentLifetime < int64(c.cfg.MaxLifetimeSessions) {
+	if currentSuccessful < int64(c.cfg.MaxLifetimeSessions) {
 		return
 	}
 
-	cmdKey := fmt.Sprintf("worker:cmd:%s", serverInfo.WorkerID())
+	cmdKey := fmt.Sprintf(workerShutdownCommandFmt, serverInfo.WorkerID())
 	wasSet, err := c.rd.SetNX(ctx, cmdKey, "shutdown", time.Duration(c.cfg.ShutdownCommandTTL)*time.Second).Result()
 	if err != nil {
 		logger.WithField("workerId", serverInfo.WorkerID()).Errorf("Failed to set shutdown command: %v", err)
@@ -141,8 +149,8 @@ func (c *Client) TriggerWorkerShutdownIfNeeded(ctx context.Context, serverInfo *
 		}
 
 		logger.WithField("workerId", serverInfo.WorkerID()).Infof(
-			"Worker has reached session limit (%d/%d). Shutdown command sent.",
-			currentLifetime,
+			"Worker has reached successful session limit (%d/%d). Shutdown command sent.",
+			currentSuccessful,
 			c.cfg.MaxLifetimeSessions,
 		)
 	}
@@ -157,10 +165,10 @@ func (c *Client) ModifyActiveConnections(ctx context.Context, serverInfo *Server
 	return nil
 }
 
-func (c *Client) ModifyLifetimeConnections(ctx context.Context, serverInfo *ServerInfo, delta int64) error {
-	err := c.rd.HIncrBy(ctx, lifetimeConnectionsKey, serverInfo.WorkerID(), int64(delta)).Err()
+func (c *Client) ModifyAllocatedSessions(ctx context.Context, serverInfo *ServerInfo, delta int64) error {
+	err := c.rd.HIncrBy(ctx, allocatedSessionsKey, serverInfo.WorkerID(), int64(delta)).Err()
 	if err != nil {
-		return fmt.Errorf("failed to modify lifetime connections for worker %s: %w", serverInfo.WorkerID(), err)
+		return fmt.Errorf("failed to modify allocated sessions for worker %s: %w", serverInfo.WorkerID(), err)
 	}
 
 	return nil
@@ -181,14 +189,25 @@ func (c *Client) GetWorker(ctx context.Context, workerId string) (ServerInfo, er
 	return serverInfo, nil
 }
 
-func (c *Client) SelectWorker(ctx context.Context, browserType string) (ServerInfo, error) {
+func (c *Client) SelectWorker(ctx context.Context, browserType string, excludedWorkerIDs []string) (ServerInfo, error) {
+	args := []any{
+		c.cfg.MaxConcurrentSessions,
+		c.cfg.MaxLifetimeSessions,
+		browserType,
+		c.cfg.SelectorFreshnessTimeout,
+	}
+	for _, excludedWorkerID := range excludedWorkerIDs {
+		if excludedWorkerID == "" {
+			continue
+		}
+		args = append(args, excludedWorkerID)
+	}
+
 	result, err := c.selectorScript.Run(
 		ctx,
 		c.rd,
 		[]string{},
-		c.cfg.MaxConcurrentSessions,
-		c.cfg.MaxLifetimeSessions,
-		browserType,
+		args...,
 	).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
@@ -197,21 +216,55 @@ func (c *Client) SelectWorker(ctx context.Context, browserType string) (ServerIn
 		return ServerInfo{}, fmt.Errorf("failed to run selector script: %w", err)
 	}
 
-	workerId, ok := result.(string)
+	resultFields, ok := result.([]any)
 	if !ok {
 		return ServerInfo{}, fmt.Errorf("selector script returned unexpected type: %T", result)
 	}
 
-	return c.GetWorker(ctx, workerId)
+	return parseSelectorResult(resultFields)
+}
+
+func parseSelectorResult(resultFields []any) (ServerInfo, error) {
+	if len(resultFields) != selectorResultFieldCount {
+		return ServerInfo{}, fmt.Errorf("selector script returned %d fields, want %d", len(resultFields), selectorResultFieldCount)
+	}
+
+	stringFields := make([]string, len(resultFields))
+	for i, rawField := range resultFields {
+		field, ok := rawField.(string)
+		if !ok {
+			return ServerInfo{}, fmt.Errorf("selector script returned non-string field at index %d: %T", i, rawField)
+		}
+		stringFields[i] = field
+	}
+
+	serverInfo := ServerInfo{
+		ID:            stringFields[0],
+		BrowserType:   stringFields[1],
+		Endpoint:      stringFields[2],
+		Status:        stringFields[3],
+		StartedAt:     stringFields[4],
+		LastHeartbeat: stringFields[5],
+	}
+
+	if slices.Contains([]string{
+		serverInfo.ID,
+		serverInfo.BrowserType,
+		serverInfo.Endpoint,
+		serverInfo.Status,
+		serverInfo.StartedAt,
+		serverInfo.LastHeartbeat,
+	}, "") {
+		return ServerInfo{}, fmt.Errorf("selector script returned incomplete worker metadata")
+	}
+
+	return serverInfo, nil
 }
 
 func (c *Client) ReapStaleWorkers(ctx context.Context) (int, error) {
-	workerIDs, err := c.rd.HKeys(ctx, lifetimeConnectionsKey).Result()
+	workerIDs, err := c.getReapCandidateWorkerIDs(ctx)
 	if err != nil {
-		if errors.Is(err, redis.Nil) {
-			return 0, nil
-		}
-		return 0, fmt.Errorf("failed to get worker IDs from lifetime connections: %w", err)
+		return 0, err
 	}
 
 	if len(workerIDs) == 0 {
@@ -223,7 +276,12 @@ func (c *Client) ReapStaleWorkers(ctx context.Context) (int, error) {
 		args[i] = v
 	}
 
-	result, err := c.reaperScript.Run(ctx, c.rd, []string{activeConnectionsKey, lifetimeConnectionsKey}, args...).Result()
+	result, err := c.reaperScript.Run(
+		ctx,
+		c.rd,
+		[]string{activeConnectionsKey, allocatedSessionsKey, successfulSessionsKey},
+		args...,
+	).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return 0, nil
@@ -241,4 +299,38 @@ func (c *Client) ReapStaleWorkers(ctx context.Context) (int, error) {
 	}
 
 	return len(reapedIDs), nil
+}
+
+func (c *Client) getReapCandidateWorkerIDs(ctx context.Context) ([]string, error) {
+	hashes := []struct {
+		key         string
+		description string
+	}{
+		{key: activeConnectionsKey, description: "active connections"},
+		{key: allocatedSessionsKey, description: "allocated sessions"},
+		{key: successfulSessionsKey, description: "successful sessions"},
+	}
+
+	workerIDSet := make(map[string]struct{})
+	for _, hash := range hashes {
+		workerIDs, err := c.rd.HKeys(ctx, hash.key).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to get worker IDs from %s: %w", hash.description, err)
+		}
+
+		for _, workerID := range workerIDs {
+			workerIDSet[workerID] = struct{}{}
+		}
+	}
+
+	workerIDs := make([]string, 0, len(workerIDSet))
+	for workerID := range workerIDSet {
+		workerIDs = append(workerIDs, workerID)
+	}
+	slices.Sort(workerIDs)
+
+	return workerIDs, nil
 }

--- a/proxy/internal/redis/client_test.go
+++ b/proxy/internal/redis/client_test.go
@@ -1,0 +1,662 @@
+package redis
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+
+	"proxy/pkg/config"
+	"proxy/pkg/logger"
+)
+
+func init() {
+	logger.Log = logrus.New()
+}
+
+type selectorTestWorker struct {
+	id            string
+	browserType   string
+	endpoint      string
+	status        string
+	startedAt     int64
+	lastHeartbeat int64
+	active        int64
+	allocated     int64
+}
+
+type redisTestServer struct {
+	addr string
+	rd   *goredis.Client
+	cmd  *exec.Cmd
+}
+
+func startRedisTestServer(t *testing.T) *redisTestServer {
+	t.Helper()
+
+	addr := os.Getenv("TEST_REDIS_ADDR")
+	if addr != "" {
+		rd := goredis.NewClient(&goredis.Options{Addr: addr})
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := rd.Ping(ctx).Err(); err != nil {
+			t.Fatalf("failed to ping test redis at %s: %v", addr, err)
+		}
+		if err := rd.FlushDB(ctx).Err(); err != nil {
+			t.Fatalf("failed to flush test redis at %s: %v", addr, err)
+		}
+
+		t.Cleanup(func() {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cleanupCancel()
+			_ = rd.FlushDB(cleanupCtx).Err()
+			_ = rd.Close()
+		})
+
+		return &redisTestServer{addr: addr, rd: rd}
+	}
+
+	redisServerPath, err := exec.LookPath("redis-server")
+	if err != nil {
+		t.Skip("redis-server not found and TEST_REDIS_ADDR is not set")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve redis port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to close reserved redis port: %v", err)
+	}
+
+	cmd := exec.Command(
+		redisServerPath,
+		"--save", "",
+		"--appendonly", "no",
+		"--bind", "127.0.0.1",
+		"--port", strconv.Itoa(port),
+		"--dir", t.TempDir(),
+	)
+
+	var stderr bytes.Buffer
+	cmd.Stdout = &stderr
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start redis-server: %v", err)
+	}
+
+	addr = fmt.Sprintf("127.0.0.1:%d", port)
+	rd := goredis.NewClient(&goredis.Options{Addr: addr})
+
+	startCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for {
+		if err := rd.Ping(startCtx).Err(); err == nil {
+			break
+		}
+
+		if startCtx.Err() != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			t.Fatalf("redis-server did not become ready: %v\n%s", startCtx.Err(), stderr.String())
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_ = rd.FlushDB(cleanupCtx).Err()
+		_ = rd.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	return &redisTestServer{addr: addr, rd: rd, cmd: cmd}
+}
+
+func newSelectorTestClient(t *testing.T, cfg *config.Config, rd *goredis.Client) *Client {
+	t.Helper()
+
+	return &Client{
+		rd:             rd,
+		cfg:            cfg,
+		selectorScript: goredis.NewScript(selectorScriptSource),
+		reaperScript:   goredis.NewScript(reaperScriptSource),
+	}
+}
+
+func newSelectorTestConfig() *config.Config {
+	return &config.Config{
+		MaxConcurrentSessions:    5,
+		MaxLifetimeSessions:      10,
+		SelectorFreshnessTimeout: 60,
+	}
+}
+
+func seedWorker(t *testing.T, rd *goredis.Client, worker selectorTestWorker) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	workerID := worker.browserType + ":" + worker.id
+	workerKey := "worker:" + workerID
+
+	if err := rd.HSet(ctx, activeConnectionsKey, workerID, worker.active).Err(); err != nil {
+		t.Fatalf("failed to seed active connections for %s: %v", workerID, err)
+	}
+	if err := rd.HSet(ctx, allocatedSessionsKey, workerID, worker.allocated).Err(); err != nil {
+		t.Fatalf("failed to seed allocated sessions for %s: %v", workerID, err)
+	}
+	if err := rd.HSet(ctx, workerKey, map[string]any{
+		"id":            worker.id,
+		"browserType":   worker.browserType,
+		"endpoint":      worker.endpoint,
+		"status":        worker.status,
+		"startedAt":     worker.startedAt,
+		"lastHeartbeat": worker.lastHeartbeat,
+	}).Err(); err != nil {
+		t.Fatalf("failed to seed worker %s: %v", workerID, err)
+	}
+
+	return workerID
+}
+
+func seedOrphanCounter(t *testing.T, rd *goredis.Client, workerID string, active, allocated int64) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := rd.HSet(ctx, activeConnectionsKey, workerID, active).Err(); err != nil {
+		t.Fatalf("failed to seed orphan active counter for %s: %v", workerID, err)
+	}
+	if err := rd.HSet(ctx, allocatedSessionsKey, workerID, allocated).Err(); err != nil {
+		t.Fatalf("failed to seed orphan allocated counter for %s: %v", workerID, err)
+	}
+}
+
+func TestClient_SelectWorkerFiltersEligibilityAndParsesMetadata(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "selected",
+		browserType:   "chromium",
+		endpoint:      "ws://selected/playwright",
+		status:        "available",
+		startedAt:     now - 10_000,
+		lastHeartbeat: now,
+		active:        1,
+		allocated:     2,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "firefox-only",
+		browserType:   "firefox",
+		endpoint:      "ws://firefox/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     0,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "draining",
+		browserType:   "chromium",
+		endpoint:      "ws://draining/playwright",
+		status:        "draining",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     0,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "shutting-down",
+		browserType:   "chromium",
+		endpoint:      "ws://shutting-down/playwright",
+		status:        "shutting-down",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     0,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "stale",
+		browserType:   "chromium",
+		endpoint:      "ws://stale/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now - 61_000,
+		active:        0,
+		allocated:     0,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	selected, err := client.SelectWorker(ctx, "chromium", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if selected.ID != "selected" {
+		t.Fatalf("expected worker ID 'selected', got %q", selected.ID)
+	}
+	if selected.BrowserType != "chromium" {
+		t.Fatalf("expected browser type chromium, got %q", selected.BrowserType)
+	}
+	if selected.Endpoint != "ws://selected/playwright" {
+		t.Fatalf("expected endpoint ws://selected/playwright, got %q", selected.Endpoint)
+	}
+	if selected.Status != "available" {
+		t.Fatalf("expected status available, got %q", selected.Status)
+	}
+	if selected.StartedAt != strconv.FormatInt(now-10_000, 10) {
+		t.Fatalf("expected startedAt %d, got %q", now-10_000, selected.StartedAt)
+	}
+	if selected.LastHeartbeat != strconv.FormatInt(now, 10) {
+		t.Fatalf("expected lastHeartbeat %d, got %q", now, selected.LastHeartbeat)
+	}
+}
+
+func TestClient_SelectWorkerIgnoresOrphanCountersAndUsesEligibleWorkerMargin(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "tier-two",
+		browserType:   "chromium",
+		endpoint:      "ws://tier-two/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     6,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "tier-one",
+		browserType:   "chromium",
+		endpoint:      "ws://tier-one/playwright",
+		status:        "available",
+		startedAt:     now - 10_000,
+		lastHeartbeat: now,
+		active:        1,
+		allocated:     2,
+	})
+	for i := 0; i < 8; i++ {
+		seedOrphanCounter(t, server.rd, fmt.Sprintf("chromium:orphan-%d", i), 0, 0)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	selected, err := client.SelectWorker(ctx, "chromium", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if selected.ID != "tier-one" {
+		t.Fatalf("expected eligible-worker margin to select tier-one, got %q", selected.ID)
+	}
+}
+
+func TestClient_SelectWorkerPrefersTierOneOverTierTwo(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "tier-two",
+		browserType:   "chromium",
+		endpoint:      "ws://tier-two/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     6,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "tier-one",
+		browserType:   "chromium",
+		endpoint:      "ws://tier-one/playwright",
+		status:        "available",
+		startedAt:     now - 10_000,
+		lastHeartbeat: now,
+		active:        1,
+		allocated:     1,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	selected, err := client.SelectWorker(ctx, "chromium", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if selected.ID != "tier-one" {
+		t.Fatalf("expected tier-one worker to win, got %q", selected.ID)
+	}
+}
+
+func TestClient_SelectWorkerPrefersLowerActiveBeforeHigherLifetimeWithinTier(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "higher-lifetime",
+		browserType:   "chromium",
+		endpoint:      "ws://higher-lifetime/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        1,
+		allocated:     4,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "lower-active",
+		browserType:   "chromium",
+		endpoint:      "ws://lower-active/playwright",
+		status:        "available",
+		startedAt:     now - 10_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     3,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	selected, err := client.SelectWorker(ctx, "chromium", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if selected.ID != "lower-active" {
+		t.Fatalf("expected least-loaded worker to win, got %q", selected.ID)
+	}
+}
+
+func TestClient_SelectWorkerUsesStartedAtThenIDTieBreaks(t *testing.T) {
+	t.Run("oldest startedAt wins", func(t *testing.T) {
+		server := startRedisTestServer(t)
+		cfg := newSelectorTestConfig()
+		client := newSelectorTestClient(t, cfg, server.rd)
+		now := time.Now().UnixMilli()
+
+		seedWorker(t, server.rd, selectorTestWorker{
+			id:            "older",
+			browserType:   "chromium",
+			endpoint:      "ws://older/playwright",
+			status:        "available",
+			startedAt:     now - 20_000,
+			lastHeartbeat: now,
+			active:        0,
+			allocated:     3,
+		})
+		seedWorker(t, server.rd, selectorTestWorker{
+			id:            "newer",
+			browserType:   "chromium",
+			endpoint:      "ws://newer/playwright",
+			status:        "available",
+			startedAt:     now - 10_000,
+			lastHeartbeat: now,
+			active:        0,
+			allocated:     3,
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		selected, err := client.SelectWorker(ctx, "chromium", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if selected.ID != "older" {
+			t.Fatalf("expected oldest worker to win, got %q", selected.ID)
+		}
+	})
+
+	t.Run("smallest ID breaks exact ties", func(t *testing.T) {
+		server := startRedisTestServer(t)
+		cfg := newSelectorTestConfig()
+		client := newSelectorTestClient(t, cfg, server.rd)
+		now := time.Now().UnixMilli()
+
+		seedWorker(t, server.rd, selectorTestWorker{
+			id:            "b-worker",
+			browserType:   "chromium",
+			endpoint:      "ws://b-worker/playwright",
+			status:        "available",
+			startedAt:     now - 20_000,
+			lastHeartbeat: now,
+			active:        0,
+			allocated:     3,
+		})
+		seedWorker(t, server.rd, selectorTestWorker{
+			id:            "a-worker",
+			browserType:   "chromium",
+			endpoint:      "ws://a-worker/playwright",
+			status:        "available",
+			startedAt:     now - 20_000,
+			lastHeartbeat: now,
+			active:        0,
+			allocated:     3,
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		selected, err := client.SelectWorker(ctx, "chromium", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if selected.ID != "a-worker" {
+			t.Fatalf("expected lexicographically smallest worker ID, got %q", selected.ID)
+		}
+	})
+}
+
+func TestClient_SelectWorkerNoEligibleWorkers(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "busy",
+		browserType:   "chromium",
+		endpoint:      "ws://busy/playwright",
+		status:        "available",
+		startedAt:     now - 10_000,
+		lastHeartbeat: now,
+		active:        int64(cfg.MaxConcurrentSessions),
+		allocated:     0,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.SelectWorker(ctx, "chromium", nil)
+	if !errors.Is(err, ErrNoAvailableWorkers) {
+		t.Fatalf("expected ErrNoAvailableWorkers, got %v", err)
+	}
+}
+
+func TestClient_SelectWorker(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	excludedWorkerID := seedWorker(t, server.rd, selectorTestWorker{
+		id:            "excluded",
+		browserType:   "chromium",
+		endpoint:      "ws://excluded/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     4,
+	})
+	seedWorker(t, server.rd, selectorTestWorker{
+		id:            "fallback",
+		browserType:   "chromium",
+		endpoint:      "ws://fallback/playwright",
+		status:        "available",
+		startedAt:     now - 10_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     3,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	selected, err := client.SelectWorker(ctx, "chromium", []string{excludedWorkerID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if selected.ID != "fallback" {
+		t.Fatalf("expected excluded worker to be skipped, got %q", selected.ID)
+	}
+}
+
+func TestClient_RecordSuccessfulSessionAndTriggerShutdownIfNeededUsesCommittedCount(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	cfg.MaxLifetimeSessions = 3
+	client := newSelectorTestClient(t, cfg, server.rd)
+	now := time.Now().UnixMilli()
+
+	workerID := seedWorker(t, server.rd, selectorTestWorker{
+		id:            "worker-1",
+		browserType:   "chromium",
+		endpoint:      "ws://worker-1/playwright",
+		status:        "available",
+		startedAt:     now - 20_000,
+		lastHeartbeat: now,
+		active:        0,
+		allocated:     3,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.rd.HSet(ctx, successfulSessionsKey, workerID, 1).Err(); err != nil {
+		t.Fatalf("failed to seed successful sessions for %s: %v", workerID, err)
+	}
+
+	serverInfo := &ServerInfo{
+		ID:          "worker-1",
+		BrowserType: "chromium",
+		Endpoint:    "ws://worker-1/playwright",
+	}
+
+	client.RecordSuccessfulSessionAndTriggerShutdownIfNeeded(ctx, serverInfo)
+
+	cmdKey := fmt.Sprintf(workerShutdownCommandFmt, workerID)
+	if exists, err := server.rd.Exists(ctx, cmdKey).Result(); err != nil {
+		t.Fatalf("failed to check shutdown command after first success: %v", err)
+	} else if exists != 0 {
+		t.Fatalf("shutdown command should not be set before the committed limit is reached")
+	}
+
+	if committed, err := server.rd.HGet(ctx, successfulSessionsKey, workerID).Int64(); err != nil {
+		t.Fatalf("failed to read committed successful sessions: %v", err)
+	} else if committed != 2 {
+		t.Fatalf("expected committed successful sessions to be 2, got %d", committed)
+	}
+
+	client.RecordSuccessfulSessionAndTriggerShutdownIfNeeded(ctx, serverInfo)
+
+	if exists, err := server.rd.Exists(ctx, cmdKey).Result(); err != nil {
+		t.Fatalf("failed to check shutdown command after second success: %v", err)
+	} else if exists != 1 {
+		t.Fatalf("expected shutdown command once committed limit was reached")
+	}
+}
+
+func TestClient_ReapStaleWorkersRemovesAllocatedAndSuccessfulSessionState(t *testing.T) {
+	server := startRedisTestServer(t)
+	cfg := newSelectorTestConfig()
+	client := newSelectorTestClient(t, cfg, server.rd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	staleWorkerID := "chromium:stale"
+	liveWorkerID := "chromium:live"
+
+	if err := server.rd.HSet(ctx, activeConnectionsKey, liveWorkerID, 1).Err(); err != nil {
+		t.Fatalf("failed to seed active state for live worker: %v", err)
+	}
+	if err := server.rd.HSet(ctx, allocatedSessionsKey, staleWorkerID, 2).Err(); err != nil {
+		t.Fatalf("failed to seed allocated state for stale worker: %v", err)
+	}
+	if err := server.rd.HSet(ctx, successfulSessionsKey, staleWorkerID, 5).Err(); err != nil {
+		t.Fatalf("failed to seed successful state for stale worker: %v", err)
+	}
+	if err := server.rd.HSet(ctx, successfulSessionsKey, liveWorkerID, 3).Err(); err != nil {
+		t.Fatalf("failed to seed successful state for live worker: %v", err)
+	}
+	if err := server.rd.HSet(ctx, "worker:"+liveWorkerID, map[string]any{
+		"id":            "live",
+		"browserType":   "chromium",
+		"endpoint":      "ws://live/playwright",
+		"status":        "available",
+		"startedAt":     time.Now().UnixMilli(),
+		"lastHeartbeat": time.Now().UnixMilli(),
+	}).Err(); err != nil {
+		t.Fatalf("failed to seed live worker metadata: %v", err)
+	}
+
+	reaped, err := client.ReapStaleWorkers(ctx)
+	if err != nil {
+		t.Fatalf("unexpected reaper error: %v", err)
+	}
+	if reaped != 1 {
+		t.Fatalf("expected 1 stale worker to be reaped, got %d", reaped)
+	}
+
+	if exists, err := server.rd.HExists(ctx, allocatedSessionsKey, staleWorkerID).Result(); err != nil {
+		t.Fatalf("failed to check allocated state for stale worker: %v", err)
+	} else if exists {
+		t.Fatal("expected stale worker allocated state to be removed")
+	}
+	if exists, err := server.rd.HExists(ctx, successfulSessionsKey, staleWorkerID).Result(); err != nil {
+		t.Fatalf("failed to check successful state for stale worker: %v", err)
+	} else if exists {
+		t.Fatal("expected stale worker successful state to be removed")
+	}
+	if exists, err := server.rd.HExists(ctx, successfulSessionsKey, liveWorkerID).Result(); err != nil {
+		t.Fatalf("failed to check successful state for live worker: %v", err)
+	} else if !exists {
+		t.Fatal("expected live worker successful state to remain")
+	}
+}

--- a/proxy/internal/redis/reaper.lua
+++ b/proxy/internal/redis/reaper.lua
@@ -1,13 +1,14 @@
 -- Atomically reaping stale workers.
 --
 -- KEYS[1]: The hash key for active connections.
--- KEYS[2]: The hash key for lifetime connections.
+-- KEYS[2]: The hash key for allocated sessions.
+-- KEYS[3]: The hash key for successful sessions.
 -- ARGV: A list of worker IDs to check for staleness.
 --
 -- For each worker ID in ARGV, this script checks if the corresponding worker
 -- heartbeat key ("worker:<worker_id>") exists. If it does not exist, the worker
--- is considered stale, and its entries are removed from the active and lifetime
--- connection hashes.
+-- is considered stale, and its entries are removed from all session-counter
+-- hashes.
 --
 -- Returns a list of worker IDs that were successfully reaped.
 
@@ -17,6 +18,7 @@ for i, worker_id in ipairs(ARGV) do
   if redis.call("EXISTS", worker_key) == 0 then
     redis.call("HDEL", KEYS[1], worker_id)
     redis.call("HDEL", KEYS[2], worker_id)
+    redis.call("HDEL", KEYS[3], worker_id)
     table.insert(reaped_ids, worker_id)
   end
 end

--- a/proxy/internal/redis/selector.lua
+++ b/proxy/internal/redis/selector.lua
@@ -1,106 +1,165 @@
--- Selects the best available worker using a lifetime-first strategy.
--- This prevents multiple workers from reaching their session limit simultaneously
--- by preferring workers with higher lifetime connections, thus staggering restarts.
--- Returns the selected worker UUID or nil if none available.
+-- Selects an eligible worker with balanced routing and an allocated-session
+-- bias. The selector stays deterministic: prefer lower active load first, then
+-- use allocated headroom to stagger restarts among otherwise similar healthy
+-- workers.
+--
+-- ARGV[1]: MAX_CONCURRENT_SESSIONS
+-- ARGV[2]: MAX_LIFETIME_SESSIONS
+-- ARGV[3]: browser type
+-- ARGV[4]: selector freshness timeout in seconds
+-- ARGV[5...]: worker IDs to exclude for this connection attempt
+--
+-- Returns selected worker metadata as:
+-- [id, browserType, endpoint, status, startedAt, lastHeartbeat]
+-- or nil if no worker is eligible.
 
 local max_concurrent_sessions = tonumber(ARGV[1])
 local max_lifetime_sessions = tonumber(ARGV[2])
--- Require a non-empty browser type argument. Unknown types naturally yield no matches.
 local browser_type = nil
 if ARGV[3] ~= nil and tostring(ARGV[3]) ~= '' then
     browser_type = tostring(ARGV[3])
 end
+local freshness_timeout_seconds = tonumber(ARGV[4])
 
-if browser_type == nil then
+if browser_type == nil or freshness_timeout_seconds == nil or freshness_timeout_seconds <= 0 then
     return nil
+end
+
+local excluded_worker_ids = {}
+for i = 5, #ARGV do
+    local excluded_worker_id = tostring(ARGV[i])
+    if excluded_worker_id ~= '' then
+        excluded_worker_ids[excluded_worker_id] = true
+    end
 end
 
 local prefix = browser_type .. ':'
-
 local active_hash = 'cluster:active_connections'
-local lifetime_hash = 'cluster:lifetime_connections'
+local allocated_hash = 'cluster:allocated_sessions'
 
 local time = redis.call('TIME')
 local now_ms = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
-local threshold = now_ms - (60 * 1000)
+local threshold = now_ms - (freshness_timeout_seconds * 1000)
+
+local allocated_data = redis.call('HGETALL', allocated_hash)
+local allocated_map = {}
+for i = 1, #allocated_data, 2 do
+    local worker_id = allocated_data[i]
+    if string.sub(worker_id, 1, #prefix) == prefix then
+        allocated_map[worker_id] = tonumber(allocated_data[i + 1] or 0)
+    end
+end
+
+local function candidate_from_worker(worker_id, active)
+    local worker_key = 'worker:' .. worker_id
+    local worker_fields = redis.call('HMGET', worker_key, 'id', 'browserType', 'endpoint', 'status', 'startedAt', 'lastHeartbeat')
+    local id = worker_fields[1]
+    local worker_browser_type = worker_fields[2]
+    local endpoint = worker_fields[3]
+    local status = worker_fields[4]
+    local started_at_str = worker_fields[5]
+    local last_heartbeat_str = worker_fields[6]
+
+    if id == false or worker_browser_type == false or endpoint == false or status == false or started_at_str == false or last_heartbeat_str == false then
+        return nil
+    end
+
+    local started_at = tonumber(started_at_str)
+    local last_heartbeat = tonumber(last_heartbeat_str)
+    local allocated = allocated_map[worker_id] or 0
+    if started_at == nil or last_heartbeat == nil then
+        return nil
+    end
+
+    if worker_browser_type ~= browser_type or status ~= 'available' then
+        return nil
+    end
+
+    if active >= max_concurrent_sessions or allocated >= max_lifetime_sessions or last_heartbeat < threshold then
+        return nil
+    end
+
+    return {
+        worker_id = worker_id,
+        id = tostring(id),
+        browser_type = tostring(worker_browser_type),
+        endpoint = tostring(endpoint),
+        status = tostring(status),
+        started_at = started_at,
+        started_at_str = tostring(started_at_str),
+        last_heartbeat_str = tostring(last_heartbeat_str),
+        active = active,
+        allocated = allocated
+    }
+end
+
+local function better_candidate(left, right)
+    if right == nil then
+        return true
+    end
+
+    if left.active ~= right.active then
+        return left.active < right.active
+    end
+
+    if left.allocated ~= right.allocated then
+        return left.allocated > right.allocated
+    end
+
+    if left.started_at ~= right.started_at then
+        return left.started_at < right.started_at
+    end
+
+    return left.id < right.id
+end
 
 local active_data = redis.call('HGETALL', active_hash)
-local lifetime_data = redis.call('HGETALL', lifetime_hash)
-local active_map = {}
-local lifetime_map = {}
+local eligible_workers = {}
 
 for i = 1, #active_data, 2 do
-    if string.sub(active_data[i], 1, #prefix) == prefix then
-        local uuid = active_data[i]
-        active_map[uuid] = tonumber(active_data[i+1] or 0)
-    end
-end
-for i = 1, #lifetime_data, 2 do
-    if string.sub(lifetime_data[i], 1, #prefix) == prefix then
-        local uuid = lifetime_data[i]
-        lifetime_map[uuid] = tonumber(lifetime_data[i+1] or 0)
-    end
-end
-
-if next(active_map) == nil then
-    return nil
-end
-local total_workers = 0
-for uuid, active in pairs(active_map) do
-    total_workers = total_workers + 1
-end
-
-local margin = math.max(1, math.floor(max_lifetime_sessions / total_workers))
-local best_uuid = nil
-local best_lifetime = -1
-local best_active = math.huge
-local fallback_uuid = nil
-local fallback_lifetime = -1
-local fallback_active = math.huge
-
-for uuid, active in pairs(active_map) do
-    local worker_key = 'worker:' .. uuid
-    -- Also fetch worker's browserType to strictly match ARGV[3]
-    local worker_fields = redis.call('HMGET', worker_key, 'status', 'lastHeartbeat', 'browserType')
-    local status = worker_fields[1]
-    local lastHeartbeat_str = worker_fields[2]
-    local worker_browser_type = worker_fields[3]
-    
-    local lifetime = lifetime_map[uuid] or 0
-
-    local is_recent = false
-    if lastHeartbeat_str then
-        local heartbeat_unix = tonumber(lastHeartbeat_str)
-        if heartbeat_unix and heartbeat_unix >= threshold then
-            is_recent = true
-        end
-    end
-    
-    -- Strictly require browser type match in addition to key prefix
-    if worker_browser_type == browser_type and status == 'available' and active < max_concurrent_sessions and lifetime < max_lifetime_sessions and is_recent then
-        if lifetime < (max_lifetime_sessions - margin) then
-            if lifetime > best_lifetime or (lifetime == best_lifetime and active < best_active) then
-                best_uuid = uuid
-                best_lifetime = lifetime
-                best_active = active
-            end
-        end
-        
-        if (lifetime + 1) <= max_lifetime_sessions and (lifetime > fallback_lifetime or (lifetime == fallback_lifetime and active < fallback_active)) then
-            fallback_uuid = uuid
-            fallback_lifetime = lifetime
-            fallback_active = active
+    local worker_id = active_data[i]
+    if string.sub(worker_id, 1, #prefix) == prefix and not excluded_worker_ids[worker_id] then
+        local active = tonumber(active_data[i + 1] or 0)
+        local candidate = candidate_from_worker(worker_id, active)
+        if candidate ~= nil then
+            table.insert(eligible_workers, candidate)
         end
     end
 end
 
-local selected_uuid = best_uuid or fallback_uuid
-
-if not selected_uuid then
+if #eligible_workers == 0 then
     return nil
 end
 
-redis.call('HINCRBY', active_hash, selected_uuid, 1)
-redis.call('HINCRBY', lifetime_hash, selected_uuid, 1)
+local margin = math.max(1, math.floor(max_lifetime_sessions / #eligible_workers))
+local primary_candidate = nil
+local fallback_candidate = nil
 
-return selected_uuid
+for _, candidate in ipairs(eligible_workers) do
+    if candidate.allocated < (max_lifetime_sessions - margin) then
+        if better_candidate(candidate, primary_candidate) then
+            primary_candidate = candidate
+        end
+    elseif (candidate.allocated + 1) <= max_lifetime_sessions then
+        if better_candidate(candidate, fallback_candidate) then
+            fallback_candidate = candidate
+        end
+    end
+end
+
+local selected = primary_candidate or fallback_candidate
+if selected == nil then
+    return nil
+end
+
+redis.call('HINCRBY', active_hash, selected.worker_id, 1)
+redis.call('HINCRBY', allocated_hash, selected.worker_id, 1)
+
+return {
+    selected.id,
+    selected.browser_type,
+    selected.endpoint,
+    selected.status,
+    selected.started_at_str,
+    selected.last_heartbeat_str
+}

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	MaxLifetimeSessions         int    `mapstructure:"MAX_LIFETIME_SESSIONS"`
 	ReaperRunInterval           int    `mapstructure:"REAPER_RUN_INTERVAL"`
 	ShutdownCommandTTL          int    `mapstructure:"SHUTDOWN_COMMAND_TTL"`
+	SelectorFreshnessTimeout    int    `mapstructure:"SELECTOR_FRESHNESS_TIMEOUT"`
 	ProxyReadHeaderTimeout      int    `mapstructure:"PROXY_READ_HEADER_TIMEOUT"`
 	ProxyWorkerSelectionTimeout int    `mapstructure:"PROXY_WORKER_SELECTION_TIMEOUT"`
 	ProxyConnectTimeout         int    `mapstructure:"PROXY_CONNECT_TIMEOUT"`
@@ -31,6 +32,7 @@ func LoadConfig() (*Config, error) {
 	viper.BindEnv("MAX_LIFETIME_SESSIONS")
 	viper.BindEnv("REAPER_RUN_INTERVAL")
 	viper.BindEnv("SHUTDOWN_COMMAND_TTL")
+	viper.BindEnv("SELECTOR_FRESHNESS_TIMEOUT")
 	viper.BindEnv("PROXY_READ_HEADER_TIMEOUT")
 	viper.BindEnv("PROXY_WORKER_SELECTION_TIMEOUT")
 	viper.BindEnv("PROXY_CONNECT_TIMEOUT")
@@ -40,6 +42,7 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault("MAX_LIFETIME_SESSIONS", 50)
 	viper.SetDefault("REAPER_RUN_INTERVAL", 300)
 	viper.SetDefault("SHUTDOWN_COMMAND_TTL", 60)
+	viper.SetDefault("SELECTOR_FRESHNESS_TIMEOUT", 60)
 	viper.SetDefault("PROXY_READ_HEADER_TIMEOUT", 5)
 	viper.SetDefault("PROXY_WORKER_SELECTION_TIMEOUT", 5)
 	viper.SetDefault("PROXY_CONNECT_TIMEOUT", 5)
@@ -56,6 +59,9 @@ func LoadConfig() (*Config, error) {
 	}
 	if cfg.RedisPort == 0 {
 		return nil, fmt.Errorf("REDIS_PORT is required")
+	}
+	if cfg.SelectorFreshnessTimeout <= 0 {
+		return nil, fmt.Errorf("SELECTOR_FRESHNESS_TIMEOUT must be greater than 0")
 	}
 	if cfg.ProxyReadHeaderTimeout <= 0 {
 		return nil, fmt.Errorf("PROXY_READ_HEADER_TIMEOUT must be greater than 0")

--- a/proxy/pkg/config/config_test.go
+++ b/proxy/pkg/config/config_test.go
@@ -19,6 +19,7 @@ func TestLoadConfig_UsesProxyTimeouts(t *testing.T) {
 
 	t.Setenv("REDIS_HOST", "redis")
 	t.Setenv("REDIS_PORT", "6379")
+	t.Setenv("SELECTOR_FRESHNESS_TIMEOUT", "45")
 	t.Setenv("PROXY_READ_HEADER_TIMEOUT", "3")
 	t.Setenv("PROXY_WORKER_SELECTION_TIMEOUT", "7")
 	t.Setenv("PROXY_CONNECT_TIMEOUT", "7")
@@ -30,6 +31,9 @@ func TestLoadConfig_UsesProxyTimeouts(t *testing.T) {
 
 	if cfg.ProxyReadHeaderTimeout != 3 {
 		t.Fatalf("expected PROXY_READ_HEADER_TIMEOUT 3, got %d", cfg.ProxyReadHeaderTimeout)
+	}
+	if cfg.SelectorFreshnessTimeout != 45 {
+		t.Fatalf("expected SELECTOR_FRESHNESS_TIMEOUT 45, got %d", cfg.SelectorFreshnessTimeout)
 	}
 	if cfg.ProxyWorkerSelectionTimeout != 7 {
 		t.Fatalf("expected PROXY_WORKER_SELECTION_TIMEOUT 7, got %d", cfg.ProxyWorkerSelectionTimeout)
@@ -53,6 +57,9 @@ func TestLoadConfig_UsesTimeoutDefaults(t *testing.T) {
 	if cfg.ProxyReadHeaderTimeout != 5 {
 		t.Fatalf("expected default PROXY_READ_HEADER_TIMEOUT 5, got %d", cfg.ProxyReadHeaderTimeout)
 	}
+	if cfg.SelectorFreshnessTimeout != 60 {
+		t.Fatalf("expected default SELECTOR_FRESHNESS_TIMEOUT 60, got %d", cfg.SelectorFreshnessTimeout)
+	}
 	if cfg.ProxyWorkerSelectionTimeout != 5 {
 		t.Fatalf("expected default PROXY_WORKER_SELECTION_TIMEOUT 5, got %d", cfg.ProxyWorkerSelectionTimeout)
 	}
@@ -67,6 +74,11 @@ func TestLoadConfig_RejectsNonPositiveTimeouts(t *testing.T) {
 		envName string
 		want    string
 	}{
+		{
+			name:    "selector freshness timeout",
+			envName: "SELECTOR_FRESHNESS_TIMEOUT",
+			want:    "SELECTOR_FRESHNESS_TIMEOUT must be greater than 0",
+		},
 		{
 			name:    "read header timeout",
 			envName: "PROXY_READ_HEADER_TIMEOUT",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,7 +15,8 @@ interface WorkerMetadata {
 }
 
 const clusterActiveConnectionsKey = 'cluster:active_connections';
-const clusterLifetimeConnectionsKey = 'cluster:lifetime_connections';
+const clusterAllocatedSessionsKey = 'cluster:allocated_sessions';
+const clusterSuccessfulSessionsKey = 'cluster:successful_sessions';
 
 
 class BrowserWorker {
@@ -171,12 +172,13 @@ class BrowserWorker {
     private async initializeCounters(): Promise<void> {
         this.logger.debug('Initializing worker connection counters in Redis...');
         try {
-            const [activeResult, lifetimeResult] = await Promise.all([
+            const [activeResult, allocatedResult, successfulResult] = await Promise.all([
                 this.redis.hSetNX(clusterActiveConnectionsKey, this.workerIdKey, String(0)),
-                this.redis.hSetNX(clusterLifetimeConnectionsKey, this.workerIdKey, String(0))
+                this.redis.hSetNX(clusterAllocatedSessionsKey, this.workerIdKey, String(0)),
+                this.redis.hSetNX(clusterSuccessfulSessionsKey, this.workerIdKey, String(0))
             ]);
 
-            if (activeResult && lifetimeResult) {
+            if (activeResult && allocatedResult && successfulResult) {
                 this.logger.debug('Successfully initialized connection counters.');
             } else {
                 this.logger.debug('Connection counters were already initialized for this worker.');


### PR DESCRIPTION
## Summary
- harden worker selection with deterministic headroom-aware routing and request-scoped worker exclusions
- tighten selection vs connect timeout behavior so reselection stays bounded without shortening the first handoff
- split optimistic allocation accounting from committed successful-session accounting to prevent premature worker drain when rollback is delayed

## Key Decisions
- The selector now returns worker metadata directly from Lua and remains the single atomic source of truth for selection plus optimistic counter increments.
- Fast selected-worker failures can trigger reselection within `PROXY_WORKER_SELECTION_TIMEOUT`, but backend dial timeouts remain terminal and still return `connect timed out after selecting worker`.
- The optimistic lifetime counter was renamed to `cluster:allocated_sessions`. It can move up and down because selection reserves lifetime budget before handoff success.
- Worker shutdown no longer uses the optimistic counter. The proxy records committed handoff success in `cluster:successful_sessions` and triggers drain from that committed count instead. This keeps async rollback from draining a healthy worker one session early.
- The selector is still O(N) over Redis worker state. That tradeoff is unchanged and now documented explicitly.

## Docs / Contract
- documents the three timeout phases and the tightened selection/reselection boundary
- documents the selector policy as balanced routing with restart bias
- documents the internal counter model: `active_connections`, `allocated_sessions`, and `successful_sessions`
- keeps the public HTTP contract unchanged from the release branch work: `worker selection timed out`, `connect timed out after selecting worker`, and `selected worker unavailable`

## Verification
- `cd proxy && go test ./...`
