### PR TITLE
docs: simplify agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,30 @@
-# Repository Guidelines
+# Project instructions
 
-## Project Structure & Module Organization
-`proxy/` contains the Go WebSocket proxy. Keep the executable entrypoint in `proxy/cmd/proxy/main.go`, proxy and Redis logic under `proxy/internal/`, and reusable config/logging helpers in `proxy/pkg/`.
+This repository contains a Go WebSocket proxy and a TypeScript Playwright
+worker.
 
-`worker/` contains the TypeScript Playwright worker. Runtime code lives in `worker/src/`, local env defaults in `worker/.env.example`, and the runtime image definition in `worker/Dockerfile`.
+## Constraints
 
-`scripts/` contains development helpers such as `scripts/check-playwright-version.js`, `scripts/test/`, and `scripts/monitor/`.
+- Preserve the proxy/worker boundary unless the task explicitly changes the
+  architecture.
+- Keep `worker/package.json`'s `playwright-core` version equal to the Playwright
+  image version in `worker/Dockerfile`. Update them together.
+- Worker code uses ES modules. Keep explicit `.js` suffixes in local imports.
+- Avoid unrelated refactors, dependencies, or repository-wide tooling changes.
 
-## Build, Test, and Development Commands
-`docker compose up -d` starts the published stack locally: Redis, proxy, and one Chromium worker.
+## Verification
 
-`docker compose -f docker-compose.local.yaml up --build` builds local images and starts Chromium, Firefox, and WebKit workers for development.
+- Proxy changes: run `cd proxy && go test ./...`.
+- Playwright version changes: run `node scripts/check-playwright-version.js`.
+- Worker runtime changes: smoke-test with
+  `docker compose -f docker-compose.local.yaml up --build`.
+- Run the checks relevant to the change and report anything you could not run.
 
-`cd proxy && go test -v ./...` runs the proxy unit test suite used in CI.
+## Git workflow
 
-`node scripts/check-playwright-version.js` verifies that `worker/package.json` and `worker/Dockerfile` use the same Playwright version.
-
-`cd worker && npm run start` runs a worker directly once `REDIS_URL`, `PORT`, and related env vars are set, but host-native startup also requires matching Playwright browser binaries to already be installed outside this repo.
-
-## Coding Style & Naming Conventions
-Follow existing language conventions rather than introducing repo-wide tooling. Go code should stay `gofmt`-clean, use lowercase package names, and keep `internal/` boundaries intact. TypeScript uses ES modules, explicit `.js` import suffixes, strict typing, and 4-space indentation. Use `PascalCase` for types/classes, `camelCase` for functions and variables, and uppercase names for env vars.
-
-Keep the worker Playwright package version synchronized across `worker/package.json` and `worker/Dockerfile`; CI enforces this.
-
-## Testing Guidelines
-Add Go tests beside the code they cover as `*_test.go`. Prefer table-driven tests for handler and selection logic. CI currently checks proxy tests, Docker image builds, and Playwright version sync; there is no dedicated worker unit suite yet, so worker changes should include a manual smoke test with `docker-compose.local.yaml`.
-
-## Commit & Pull Request Guidelines
-Recent history favors short, imperative commit subjects. Dependency bumps follow `Bump <package> from <old> to <new> in /worker`; keep that format for version-only updates.
-
-Keep PRs narrowly scoped to one area when possible. Include a brief behavior summary, note any env or Docker changes, link related issues, and list the commands you ran to verify the change.
+- Use one branch and one pull request per task.
+- Use Conventional Commits, for example `fix(proxy): handle closed connections`
+  or `chore(deps): update Playwright`.
+- Never add AI attribution or co-author trailers.
+- Keep pull requests focused. Include the behavior change, configuration impact,
+  and verification performed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- replace broad repository guidance with concise, project-specific constraints
- document exact verification commands and Conventional Commit expectations
- expose the same instructions to Claude Code through a relative `CLAUDE.md` symlink

## Impact

Agents receive less redundant context while retaining the Playwright version invariant, relevant checks, and Git workflow.

## Verification

- `git diff --cached --check`
- verified `CLAUDE.md` is a relative symlink to `AGENTS.md`
- verified both paths resolve to identical content

No runtime checks were run because this change only affects documentation.