### PR TITLE
ci: enforce Conventional Commit PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     open-pull-requests-limit: 5
     labels: ["dependencies", "worker"]
     assignees: ["mbroton"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
   - package-ecosystem: docker
     directory: "/worker"
     schedule:
@@ -14,3 +18,6 @@ updates:
     open-pull-requests-limit: 3
     labels: ["dependencies", "worker"]
     assignees: ["mbroton"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  title:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?!?: .+$'
+
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            exit 0
+          fi
+
+          echo "::error title=Invalid pull request title::Use Conventional Commits, for example: fix(proxy): handle closed connections"
+          exit 1


### PR DESCRIPTION
## Summary

- validate pull request titles against the repository's Conventional Commit types
- rerun validation when a title is edited
- configure npm and Docker Dependabot updates to use `chore(deps): …` titles
- avoid third-party actions and repository checkout

## Repository settings

GitHub is now configured to allow squash merges only. Squashed commits use the pull request title and body. The `Conventional Commit title` check is required on `main`, including for administrators.

## Impact

Pull request titles become the single commit titles on `main`. Invalid titles fail with an example showing the expected format.

## Verification

- GitHub ran `Conventional Commit title` successfully on this PR
- parsed both changed YAML files locally
- tested valid titles with scopes and breaking-change markers
- tested invalid titles for uppercase types, missing types, empty scopes, and misplaced spaces
- all existing CI checks passed before the Dependabot configuration update