### PR TITLE
ci: group Playwright dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,30 @@
 version: 2
+
+multi-ecosystem-groups:
+  playwright:
+    schedule:
+      interval: weekly
+    labels: ["dependencies", "worker"]
+    assignees: ["mbroton"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
 updates:
+  # Playwright's package and runtime image must change in the same pull request.
+  - package-ecosystem: npm
+    directory: "/worker"
+    patterns: ["playwright-core"]
+    multi-ecosystem-group: playwright
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: "/worker"
+    patterns: ["mcr.microsoft.com/playwright"]
+    multi-ecosystem-group: playwright
+    schedule:
+      interval: weekly
+  # Keep unrelated npm updates in focused pull requests.
   - package-ecosystem: npm
     directory: "/worker"
     schedule:
@@ -7,17 +32,9 @@ updates:
     open-pull-requests-limit: 5
     labels: ["dependencies", "worker"]
     assignees: ["mbroton"]
+    ignore:
+      - dependency-name: "playwright-core"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
-  - package-ecosystem: docker
-    directory: "/worker"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 3
-    labels: ["dependencies", "worker"]
-    assignees: ["mbroton"]
-    commit-message:
-      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary

- group `playwright-core` and the Playwright Docker image into one Dependabot pull request
- keep unrelated npm dependency updates in separate pull requests
- preserve Conventional Commit titles for both update paths

## Root cause

Dependabot treated npm and Docker as independent ecosystems. A Docker-only update changed the image while `package.json` stayed pinned, so the version invariant correctly failed. PR #70 reproduced this as `Dockerfile 1.62.1` versus `package.json 1.58.1`; PR #62 represents the opposite half.

## Impact

Future Playwright version updates will change the package, lockfile, and runtime image together. The existing version check remains strict.

GitHub documents multi-ecosystem groups for dependencies that must be updated together: https://docs.github.com/en/code-security/concepts/supply-chain-security/multi-ecosystem-updates

## Verification

- validated `.github/dependabot.yml` against the current SchemaStore schema
- `node scripts/check-playwright-version.js` passes for matching 1.58.1 versions
- the same check fails for a temporary Docker-only 1.58.2 update
- inspected the failing GitHub Actions log for PR #70

GitHub can create the grouped Dependabot pull request only after this configuration reaches `main`; that is the remaining end-to-end check.