### PR TITLE
fix(ci): match Playwright Docker dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       interval: weekly
   - package-ecosystem: docker
     directory: "/worker"
-    patterns: ["mcr.microsoft.com/playwright"]
+    patterns: ["playwright"]
     multi-ecosystem-group: playwright
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

Match the Docker dependency by Dependabot's name, `playwright`, so the multi-ecosystem group can update the npm package and Docker image together.

## Root cause

The configuration matched the full registry path, `mcr.microsoft.com/playwright`. Dependabot's Docker update log reported that the `playwright` group matched no allowed dependency, so PR #78 changed only `worker/package.json` and `worker/package-lock.json` and failed the version check.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'`
- `node scripts/check-playwright-version.js`
- `git diff --check`

After this merges, Dependabot must refresh the grouped update before we can verify the complete npm-and-Docker path.