### PR TITLE
fix(ci): use Playwright group schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,10 @@ updates:
     directory: "/worker"
     patterns: ["playwright-core"]
     multi-ecosystem-group: playwright
-    schedule:
-      interval: weekly
   - package-ecosystem: docker
     directory: "/worker"
     patterns: ["playwright"]
     multi-ecosystem-group: playwright
-    schedule:
-      interval: weekly
   # Keep unrelated npm updates in focused pull requests.
   - package-ecosystem: npm
     directory: "/worker"


### PR DESCRIPTION
## Summary

Remove the npm and Docker schedules from the two Playwright group entries. The top-level `playwright` group now owns their shared weekly schedule.

## Root cause

The manual dependency checks ran the ecosystem entries separately with multi-ecosystem mode disabled. Dependabot created Docker-only PR #80 and npm-only PR #81, and both failed the version check.

This layout now matches GitHub's documented multi-ecosystem example: grouped ecosystem entries select dependencies, while the group defines the schedule.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'`
- `node scripts/check-playwright-version.js`
- `git diff --check`

After this merges, the next group run must produce one PR that changes `worker/package.json`, `worker/package-lock.json`, and `worker/Dockerfile`.