### PR TITLE
fix(ci): prevent partial Playwright updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,21 +16,10 @@ updates:
     directory: "/worker"
     patterns: ["playwright-core"]
     multi-ecosystem-group: playwright
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "worker"]
+    assignees: ["mbroton"]
   - package-ecosystem: docker
     directory: "/worker"
     patterns: ["playwright"]
     multi-ecosystem-group: playwright
-  # Keep unrelated npm updates in focused pull requests.
-  - package-ecosystem: npm
-    directory: "/worker"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    labels: ["dependencies", "worker"]
-    assignees: ["mbroton"]
-    ignore:
-      - dependency-name: "playwright-core"
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-      include: "scope"


### PR DESCRIPTION
## Summary

- consolidate worker npm updates into one Dependabot entry
- keep `playwright-core` in the Playwright multi-ecosystem group
- raise the npm open pull request limit from 5 to 10

## Root cause

The scheduled Playwright group run created #88 with only the Docker image update. At that time, five npm version-update pull requests were already open, matching Dependabot's default limit. The configuration also defined two overlapping npm entries for `/worker`, which GitHub does not support.

The npm registry already contained `playwright-core` 1.62.1, so registry availability was not the blocker.

## Impact

Playwright updates have room to join the multi-ecosystem pull request even when the five unrelated worker dependencies already have open updates. Other npm dependencies remain eligible for individual updates from the same npm entry.

## Verification

- parsed `.github/dependabot.yml` with PyYAML
- confirmed exactly one npm `/worker` entry
- confirmed the entry targets `playwright-core`, belongs to the `playwright` group, and has a limit of 10
- `git diff --check`