### PR TITLE
fix(worker): handle Redis outages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
           done
           exit 1
 
+      - name: Test worker Redis resilience
+        run: scripts/test/worker-redis-resilience.sh
+
       - name: Show service logs on failure
         if: failure()
         run: docker compose -f docker-compose.local.yaml logs

--- a/scripts/test/worker-redis-resilience.sh
+++ b/scripts/test/worker-redis-resilience.sh
@@ -56,6 +56,21 @@ wait_for_worker_restart() {
     return 1
 }
 
+wait_for_worker_log() {
+    local expected="$1"
+    local worker_logs
+
+    for _ in {1..15}; do
+        worker_logs=$("${compose[@]}" logs worker)
+        if [[ "$worker_logs" == *"$expected"* ]]; then
+            return
+        fi
+        sleep 1
+    done
+
+    return 1
+}
+
 wait_for_new_worker_registration() {
     local previous_key="$1"
     local worker_keys
@@ -105,8 +120,7 @@ if (( $(worker_restart_count) != initial_restart_count )); then
     exit 1
 fi
 
-worker_logs=$("${compose[@]}" logs worker)
-if [[ "$worker_logs" != *'Redis state restored after reconnect'* ]]; then
+if ! wait_for_worker_log 'Redis state restored after reconnect'; then
     echo 'Worker did not restore its Redis state after reconnecting.' >&2
     exit 1
 fi

--- a/scripts/test/worker-redis-resilience.sh
+++ b/scripts/test/worker-redis-resilience.sh
@@ -8,8 +8,12 @@ if [[ -n "${COMPOSE_OVERRIDE_FILE:-}" ]]; then
 fi
 ws_endpoint="${WS_ENDPOINT:-ws://127.0.0.1:8080}"
 
-worker_start_time() {
-    "${compose[@]}" exec -T worker sh -c "awk '{print \$22}' /proc/1/stat"
+worker_container_id() {
+    "${compose[@]}" ps -q worker
+}
+
+worker_restart_count() {
+    docker inspect --format '{{.RestartCount}}' "$(worker_container_id)"
 }
 
 wait_for_redis() {
@@ -37,12 +41,12 @@ run_smoke_test() {
 }
 
 wait_for_worker_restart() {
-    local previous_start_time="$1"
-    local current_start_time
+    local previous_count="$1"
+    local current_count
 
     for _ in {1..30}; do
-        current_start_time=$(worker_start_time 2>/dev/null || true)
-        if [[ -n "$current_start_time" && "$current_start_time" != "$previous_start_time" ]]; then
+        current_count=$(worker_restart_count 2>/dev/null || true)
+        if [[ -n "$current_count" ]] && (( current_count > previous_count )); then
             return
         fi
         sleep 1
@@ -70,7 +74,7 @@ wait_for_new_worker_registration() {
     return 1
 }
 
-initial_start_time="$(worker_start_time)"
+initial_restart_count="$(worker_restart_count)"
 
 "${compose[@]}" stop redis
 
@@ -96,7 +100,7 @@ fi
 wait_for_redis
 run_smoke_test
 
-if [[ "$(worker_start_time)" != "$initial_start_time" ]]; then
+if (( $(worker_restart_count) != initial_restart_count )); then
     echo 'Worker restarted during a recoverable Redis outage.' >&2
     exit 1
 fi
@@ -113,16 +117,16 @@ if [[ -z "$worker_key" ]]; then
     exit 1
 fi
 
-start_time_before_shutdown="$(worker_start_time)"
+restart_count_before_shutdown="$(worker_restart_count)"
 command_channel="worker:cmd:${worker_key#worker:}"
 "${compose[@]}" exec -T redis redis-cli publish "$command_channel" shutdown >/dev/null
-wait_for_worker_restart "$start_time_before_shutdown"
+wait_for_worker_restart "$restart_count_before_shutdown"
 run_smoke_test
 
 worker_key_before_long_outage=$("${compose[@]}" exec -T redis redis-cli --raw --scan --pattern 'worker:chromium:*' | head -n 1)
-start_time_before_long_outage="$(worker_start_time)"
+restart_count_before_long_outage="$(worker_restart_count)"
 "${compose[@]}" stop redis
-wait_for_worker_restart "$start_time_before_long_outage"
+wait_for_worker_restart "$restart_count_before_long_outage"
 
 worker_logs=$("${compose[@]}" logs worker)
 if ! grep -Eq '"exitCode":[[:space:]]*1' <<< "$worker_logs"; then

--- a/scripts/test/worker-redis-resilience.sh
+++ b/scripts/test/worker-redis-resilience.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+compose=(docker compose -f docker-compose.local.yaml)
+if [[ -n "${COMPOSE_OVERRIDE_FILE:-}" ]]; then
+    compose+=(-f "$COMPOSE_OVERRIDE_FILE")
+fi
+ws_endpoint="${WS_ENDPOINT:-ws://127.0.0.1:8080}"
+
+worker_start_time() {
+    "${compose[@]}" exec -T worker sh -c "awk '{print \$22}' /proc/1/stat"
+}
+
+wait_for_redis() {
+    for _ in {1..30}; do
+        if "${compose[@]}" exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; then
+            return
+        fi
+        sleep 1
+    done
+
+    echo 'Redis did not become ready.' >&2
+    return 1
+}
+
+run_smoke_test() {
+    for _ in {1..15}; do
+        if WS_ENDPOINT="$ws_endpoint" npm --prefix worker run smoke; then
+            return
+        fi
+        sleep 2
+    done
+
+    echo 'Smoke test did not pass.' >&2
+    return 1
+}
+
+wait_for_worker_restart() {
+    local previous_start_time="$1"
+    local current_start_time
+
+    for _ in {1..30}; do
+        current_start_time=$(worker_start_time 2>/dev/null || true)
+        if [[ -n "$current_start_time" && "$current_start_time" != "$previous_start_time" ]]; then
+            return
+        fi
+        sleep 1
+    done
+
+    echo 'Worker did not restart.' >&2
+    return 1
+}
+
+wait_for_new_worker_registration() {
+    local previous_key="$1"
+    local worker_keys
+
+    for _ in {1..30}; do
+        worker_keys=$("${compose[@]}" exec -T redis redis-cli --raw --scan --pattern 'worker:chromium:*')
+        while IFS= read -r worker_key; do
+            if [[ -n "$worker_key" && "$worker_key" != "$previous_key" ]]; then
+                return
+            fi
+        done <<< "$worker_keys"
+        sleep 1
+    done
+
+    echo 'Restarted worker did not register in Redis.' >&2
+    return 1
+}
+
+initial_start_time="$(worker_start_time)"
+
+"${compose[@]}" stop redis
+
+set +e
+startup_output=$("${compose[@]}" run --rm --no-deps \
+    -e REDIS_URL=redis://:redis-log-secret@redis:6379 \
+    -e REDIS_RETRY_ATTEMPTS=1 \
+    worker 2>&1)
+startup_status=$?
+set -e
+
+if (( startup_status == 0 )); then
+    echo 'Worker unexpectedly started without Redis.' >&2
+    exit 1
+fi
+
+if [[ "$startup_output" == *redis-log-secret* ]]; then
+    echo 'Worker exposed Redis credentials in its startup logs.' >&2
+    exit 1
+fi
+
+"${compose[@]}" start redis
+wait_for_redis
+run_smoke_test
+
+if [[ "$(worker_start_time)" != "$initial_start_time" ]]; then
+    echo 'Worker restarted during a recoverable Redis outage.' >&2
+    exit 1
+fi
+
+worker_logs=$("${compose[@]}" logs worker)
+if [[ "$worker_logs" != *'Redis state restored after reconnect'* ]]; then
+    echo 'Worker did not restore its Redis state after reconnecting.' >&2
+    exit 1
+fi
+
+worker_key=$("${compose[@]}" exec -T redis redis-cli --raw --scan --pattern 'worker:chromium:*' | head -n 1)
+if [[ -z "$worker_key" ]]; then
+    echo 'No Chromium worker registration found in Redis.' >&2
+    exit 1
+fi
+
+start_time_before_shutdown="$(worker_start_time)"
+command_channel="worker:cmd:${worker_key#worker:}"
+"${compose[@]}" exec -T redis redis-cli publish "$command_channel" shutdown >/dev/null
+wait_for_worker_restart "$start_time_before_shutdown"
+run_smoke_test
+
+worker_key_before_long_outage=$("${compose[@]}" exec -T redis redis-cli --raw --scan --pattern 'worker:chromium:*' | head -n 1)
+start_time_before_long_outage="$(worker_start_time)"
+"${compose[@]}" stop redis
+wait_for_worker_restart "$start_time_before_long_outage"
+
+worker_logs=$("${compose[@]}" logs worker)
+if ! grep -Eq '"exitCode":[[:space:]]*1' <<< "$worker_logs"; then
+    echo 'Worker did not report a failed exit after exhausting Redis reconnects.' >&2
+    exit 1
+fi
+
+"${compose[@]}" start redis
+wait_for_redis
+wait_for_new_worker_registration "$worker_key_before_long_outage"
+
+echo 'Worker Redis resilience test passed.'

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,5 @@
 import { chromium, firefox, webkit, type BrowserServer } from 'playwright-core';
-import { createClient, type RedisClientType } from 'redis';
+import { createClient } from 'redis';
 import { loadConfig } from './config.js';
 import type { WorkerConfig } from './config.js';
 import { Logger } from './logger.js';
@@ -16,6 +16,7 @@ interface WorkerMetadata {
 
 const clusterActiveConnectionsKey = 'cluster:active_connections';
 const clusterLifetimeConnectionsKey = 'cluster:lifetime_connections';
+type RedisClient = ReturnType<typeof createClient>;
 
 
 class BrowserWorker {
@@ -24,8 +25,8 @@ class BrowserWorker {
     private readonly logger: Logger;
     private browserServer: BrowserServer | null = null;
 
-    private readonly redis: RedisClientType;
-    private readonly redisSub: RedisClientType;
+    private readonly redis: RedisClient;
+    private readonly redisSub: RedisClient;
     private readonly redisKey: string;
     private readonly redisCmdKey: string;
     private readonly workerIdKey: string;
@@ -33,6 +34,8 @@ class BrowserWorker {
     // State
     private isShuttingDown: boolean = false;
     private isDraining: boolean = false;
+    private isRunning: boolean = false;
+    private isRestoringRedisState: boolean = false;
     private internalEndpoint: string | null = null;
     private startedAt: number | null = null;
 
@@ -45,8 +48,8 @@ class BrowserWorker {
         this.workerId = crypto.randomUUID();
         this.config = loadConfig();
         this.logger = new Logger(this.workerId, this.config.logging.level, this.config.logging.format);
-        this.redis = createClient({ url: this.config.redis.url });
-        this.redisSub = createClient({ url: this.config.redis.url });
+        this.redis = this.createRedisClient('main');
+        this.redisSub = this.createRedisClient('subscription');
         this.redisKey = `worker:${this.config.server.browserType}:${this.workerId}`;
         this.redisCmdKey = `worker:cmd:${this.config.server.browserType}:${this.workerId}`;
         this.workerIdKey = `${this.config.server.browserType}:${this.workerId}`;
@@ -59,35 +62,63 @@ class BrowserWorker {
         return { message: String(error) };
     }
 
-    private async connectRedisClient(client: RedisClientType, purpose: string): Promise<void> {
-        let attempts = 0;
-        this.logger.debug(`Connecting to Redis for ${purpose}...`, { url: this.config.redis.url });
-        while (attempts < this.config.redis.retryAttempts) {
-            try {
-                await Promise.race([
-                    client.connect(),
-                    new Promise((_, reject) =>
-                        setTimeout(() => reject(new Error('Redis connection timed out')), 2000)
-                    )
-                ]);
-
-                await client.ping();
-
-                this.logger.debug(`Successfully connected to Redis for ${purpose}`, { url: this.config.redis.url });
-                return;
-            } catch (error) {
-                attempts++;
-                this.logger.warn(`Redis connection attempt failed for ${purpose}`, {
-                    attempt: attempts,
-                    maxAttempts: this.config.redis.retryAttempts,
-                    error: this.formatError(error)
-                });
-                if (attempts >= this.config.redis.retryAttempts) {
-                    throw new Error(`Failed to connect to Redis for ${purpose} after ${attempts} attempts.`);
+    private createRedisClient(purpose: string): RedisClient {
+        let hasConnected = false;
+        const client = createClient({
+            url: this.config.redis.url,
+            disableOfflineQueue: true,
+            socket: {
+                connectTimeout: 2000,
+                reconnectStrategy: (retries, cause) => {
+                    if (retries + 1 >= this.config.redis.retryAttempts) {
+                        return new Error(
+                            `Redis ${purpose} reconnect attempts exhausted: ${cause.message}`
+                        );
+                    }
+                    return this.config.redis.retryDelay;
                 }
-                await new Promise(resolve => setTimeout(resolve, this.config.redis.retryDelay));
             }
-        }
+        });
+
+        client.on('error', (error) => {
+            this.logger.warn(`Redis ${purpose} client error`, {
+                error: this.formatError(error)
+            });
+
+            if (this.isRunning && !this.isShuttingDown && !client.isOpen) {
+                void this.gracefulShutdown(`redis_${purpose}_reconnect_exhausted`, 1);
+            }
+        });
+
+        client.on('reconnecting', () => {
+            this.logger.warn(`Redis ${purpose} client reconnecting`);
+        });
+
+        client.on('ready', () => {
+            if (!hasConnected) {
+                hasConnected = true;
+                this.logger.debug(`Redis ${purpose} client connected`);
+                return;
+            }
+
+            this.logger.info(`Redis ${purpose} client reconnected`);
+            if (purpose === 'main' && this.isRunning && !this.isShuttingDown) {
+                void this.restoreRedisState();
+            }
+        });
+
+        client.on('end', () => {
+            this.logger.debug(`Redis ${purpose} client closed`);
+        });
+
+        return client;
+    }
+
+    private async connectRedisClient(client: RedisClient, purpose: string): Promise<void> {
+        this.logger.debug(`Connecting to Redis for ${purpose}...`);
+        await client.connect();
+        await client.ping();
+        this.logger.debug(`Successfully connected to Redis for ${purpose}`);
     }
 
     private async listenForCommands(): Promise<void> {
@@ -114,7 +145,11 @@ class BrowserWorker {
     }
 
     public async start(): Promise<void> {
-        this.logger.info('Starting browser worker...', { config: this.config });
+        this.logger.info('Starting browser worker...', {
+            browserType: this.config.server.browserType,
+            port: this.config.server.port,
+            headless: this.config.server.headless
+        });
 
         try {
             await Promise.all([
@@ -155,6 +190,7 @@ class BrowserWorker {
             await this.initializeCounters();
             await this.register();
 
+            this.isRunning = true;
             this.startHeartbeat();
 
             process.on('SIGINT', () => this.gracefulShutdown('SIGINT'));
@@ -165,6 +201,25 @@ class BrowserWorker {
         } catch (error) {
             this.logger.error('Failed to start browser worker', { error: this.formatError(error) });
             await this.cleanupAndExit(1);
+        }
+    }
+
+    private async restoreRedisState(): Promise<void> {
+        if (this.isRestoringRedisState || this.isShuttingDown || !this.redis.isReady) {
+            return;
+        }
+
+        this.isRestoringRedisState = true;
+        try {
+            await this.initializeCounters();
+            await this.register();
+            this.logger.info('Redis state restored after reconnect');
+        } catch (error) {
+            this.logger.error('Failed to restore Redis state after reconnect', {
+                error: this.formatError(error)
+            });
+        } finally {
+            this.isRestoringRedisState = false;
         }
     }
 
@@ -222,12 +277,13 @@ class BrowserWorker {
     }
 
     private async performHeartbeat(): Promise<void> {
-        if (this.isShuttingDown) return;
+        if (this.isShuttingDown || this.isRestoringRedisState || !this.redis.isReady) return;
 
         try {
             const exists = await this.redis.exists(this.redisKey);
             if (!exists) {
                 this.logger.warn('Worker key expired. Re-registering...');
+                await this.initializeCounters();
                 await this.register();
                 return;
             }
@@ -250,8 +306,10 @@ class BrowserWorker {
             }
 
         } catch (error) {
-            this.logger.error('Failed to perform heartbeat', { error: this.formatError(error) });
-            await this.gracefulShutdown('heartbeat_error');
+            this.logger.warn('Failed to perform heartbeat', { error: this.formatError(error) });
+            if (!this.redis.isOpen) {
+                await this.gracefulShutdown('redis_main_reconnect_exhausted', 1);
+            }
         }
     }
 
@@ -311,7 +369,7 @@ class BrowserWorker {
         }, 1000);
     }
 
-    private async gracefulShutdown(initiator: string): Promise<void> {
+    private async gracefulShutdown(initiator: string, exitCode: number = 0): Promise<void> {
         if (this.isShuttingDown) return;
         this.isShuttingDown = true;
         this.isDraining = false;
@@ -332,11 +390,13 @@ class BrowserWorker {
         }
 
         try {
-            this.logger.debug('Updating worker status to "shutting-down" in Redis.');
-            const exists = await this.redis.exists(this.redisKey);
-            if (exists) {
-                await this.redis.hSet(this.redisKey, 'status', 'shutting-down');
-                await this.redis.expire(this.redisKey, 10);
+            if (this.redis.isReady) {
+                this.logger.debug('Updating worker status to "shutting-down" in Redis.');
+                const exists = await this.redis.exists(this.redisKey);
+                if (exists) {
+                    await this.redis.hSet(this.redisKey, 'status', 'shutting-down');
+                    await this.redis.expire(this.redisKey, 10);
+                }
             }
         } catch (error) {
             this.logger.error('Failed to update worker status during shutdown.', { error: this.formatError(error) });
@@ -348,7 +408,20 @@ class BrowserWorker {
             this.logger.info('Browser server closed.');
         }
 
-        await this.cleanupAndExit(0);
+        await this.cleanupAndExit(exitCode);
+    }
+
+    private async closeRedisClient(client: RedisClient): Promise<void> {
+        if (!client.isOpen) {
+            return;
+        }
+
+        if (client.isReady) {
+            await client.quit();
+            return;
+        }
+
+        await client.disconnect();
     }
 
     private async cleanupAndExit(exitCode: number): Promise<void> {
@@ -363,16 +436,18 @@ class BrowserWorker {
         }
 
         try {
-            await this.redis.del(this.redisKey);
-            this.logger.debug('Worker key removed from Redis.');
+            if (this.redis.isReady) {
+                await this.redis.del(this.redisKey);
+                this.logger.debug('Worker key removed from Redis.');
+            }
         } catch (error) {
             this.logger.error('Failed to remove worker key from Redis during cleanup.', { error: this.formatError(error) });
         }
 
         try {
             await Promise.all([
-                this.redis.quit(),
-                this.redisSub.quit()
+                this.closeRedisClient(this.redis),
+                this.closeRedisClient(this.redisSub)
             ]);
             this.logger.debug('Redis connections closed.');
         } catch (error) {


### PR DESCRIPTION
## Summary

- add bounded reconnect handling for the main and Pub/Sub Redis clients
- restore worker counters and registration after a recoverable outage
- exit with status 1 after the retry budget is exhausted so Docker can restart the worker
- stop logging the Redis URL and add container-level resilience coverage to CI

## Root cause

The worker did not attach Redis error handlers. A dropped connection could therefore crash the process, and heartbeat failures forced immediate shutdown instead of allowing node-redis to reconnect. Startup logs also included the complete Redis URL.

## Configuration impact

No new configuration is required. `REDIS_RETRY_ATTEMPTS` and `REDIS_RETRY_DELAY` now bound both startup and runtime reconnects.

## Verification

- `npm --prefix worker run typecheck`
- `node scripts/check-playwright-version.js`
- `shellcheck scripts/test/worker-redis-resilience.sh`
- `cd proxy && go test ./...`
- full Docker resilience test covering startup failure, credential-safe logs, short-outage recovery, Pub/Sub shutdown after reconnect, and long-outage restart