### PR TITLE
chore(worker): upgrade Redis client to v6

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "dotenv": "^17.4.2",
         "playwright-core": "1.58.1",
-        "redis": "^4.6.15",
+        "redis": "^6.2.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -436,62 +436,70 @@
       }
     },
     "node_modules/@redis/bloom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
-      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.2.1.tgz",
+      "integrity": "sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
-      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.2.1.tgz",
+      "integrity": "sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==",
       "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@redis/graph": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
-      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
-      "license": "MIT",
+        "node": ">= 20.0.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
-      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.2.1.tgz",
+      "integrity": "sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "node_modules/@redis/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz",
+      "integrity": "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
-      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.2.1.tgz",
+      "integrity": "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "node_modules/@types/node": {
@@ -507,7 +515,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -564,15 +571,6 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/playwright-core": {
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
@@ -586,20 +584,18 @@
       }
     },
     "node_modules/redis": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
-      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
-      "license": "MIT",
-      "workspaces": [
-        "./packages/*"
-      ],
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.2.1.tgz",
+      "integrity": "sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==",
       "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.6.1",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.7",
-        "@redis/search": "1.2.0",
-        "@redis/time-series": "1.1.0"
+        "@redis/bloom": "6.2.1",
+        "@redis/client": "6.2.1",
+        "@redis/json": "6.2.1",
+        "@redis/search": "6.2.1",
+        "@redis/time-series": "6.2.1"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/tsx": {
@@ -653,12 +649,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/worker/package.json
+++ b/worker/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "dotenv": "^17.4.2",
     "playwright-core": "1.58.1",
-    "redis": "^4.6.15",
+    "redis": "^6.2.1",
     "zod": "^4.4.3"
   }
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,5 +1,5 @@
 import { chromium, firefox, webkit, type BrowserServer } from 'playwright-core';
-import { createClient } from 'redis';
+import { createClient, type RedisClientType } from 'redis';
 import { loadConfig } from './config.js';
 import type { WorkerConfig } from './config.js';
 import { Logger } from './logger.js';
@@ -16,7 +16,7 @@ interface WorkerMetadata {
 
 const clusterActiveConnectionsKey = 'cluster:active_connections';
 const clusterLifetimeConnectionsKey = 'cluster:lifetime_connections';
-type RedisClient = ReturnType<typeof createClient>;
+type RedisClient = RedisClientType<{}, {}, {}, 2>;
 
 
 class BrowserWorker {
@@ -66,6 +66,7 @@ class BrowserWorker {
         let hasConnected = false;
         const client = createClient({
             url: this.config.redis.url,
+            RESP: 2,
             disableOfflineQueue: true,
             socket: {
                 connectTimeout: 2000,
@@ -420,11 +421,11 @@ class BrowserWorker {
         }
 
         if (client.isReady) {
-            await client.quit();
+            await client.close();
             return;
         }
 
-        await client.disconnect();
+        client.destroy();
     }
 
     private async cleanupAndExit(exitCode: number): Promise<void> {


### PR DESCRIPTION
## Summary

- upgrade node-redis from 4.7.1 to 6.2.1
- replace deprecated shutdown methods with `close()` and `destroy()`
- pin RESP2 to preserve the worker's existing protocol behavior during the major upgrade
- narrow the Redis client type to the selected protocol

## Impact

The worker keeps its existing Redis command and reply behavior. Node-redis 6 requires Node 20 or newer; the worker image runs Node 24.

## Verification

- `cd worker && npm ci`
- `cd worker && npm run typecheck`
- `cd worker && npm audit` — zero vulnerabilities
- local worker image build
- Chromium, Firefox, and WebKit smoke tests
- Redis startup-failure and credential-redaction checks
- recoverable outage and state-restoration check
- Pub/Sub drain and graceful shutdown check
- reconnect-exhaustion and worker restart check