### PR TITLE
chore(worker): upgrade Playwright to 1.62.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(await page.title());
 await browser.close();
 ```
 
-> Want Firefox or WebKit? Append `?browser=firefox` or `?browser=webkit` to the WebSocket URL and use the matching Playwright client (`p.firefox.connect`, `p.webkit.connect`, etc.).
+> Want Firefox or WebKit? Append `/?browser=firefox` or `/?browser=webkit` to the WebSocket URL and use the matching Playwright client (`p.firefox.connect`, `p.webkit.connect`, etc.).
 That's it! The same `ws://localhost:8080` endpoint works with any Playwright client (Node.js, Python, Java, .NET, etc.).
 
 
@@ -111,11 +111,11 @@ console.log(await page.title());
 await browser.close();
 
 // Target Firefox workers explicitly.
-const firefoxBrowser = await firefox.connect('ws://localhost:8080?browser=firefox');
+const firefoxBrowser = await firefox.connect('ws://localhost:8080/?browser=firefox');
 await firefoxBrowser.close();
 
 // Or WebKit workers.
-const webkitBrowser = await webkit.connect('ws://localhost:8080?browser=webkit');
+const webkitBrowser = await webkit.connect('ws://localhost:8080/?browser=webkit');
 await webkitBrowser.close();
 ```
 
@@ -136,11 +136,11 @@ async def main():
         await browser.close()
 
         # Firefox
-        firefox = await p.firefox.connect('ws://localhost:8080?browser=firefox')
+        firefox = await p.firefox.connect('ws://localhost:8080/?browser=firefox')
         await firefox.close()
 
         # WebKit
-        webkit = await p.webkit.connect('ws://localhost:8080?browser=webkit')
+        webkit = await p.webkit.connect('ws://localhost:8080/?browser=webkit')
         await webkit.close()
 
 asyncio.run(main())

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.58.1
+FROM mcr.microsoft.com/playwright:v1.62.1
 
 WORKDIR /browser_server
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -7,7 +7,7 @@
       "name": "worker",
       "dependencies": {
         "dotenv": "^17.4.2",
-        "playwright-core": "1.58.1",
+        "playwright-core": "1.62.1",
         "redis": "^6.2.1",
         "zod": "^4.4.3"
       },
@@ -572,15 +572,14 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-      "license": "Apache-2.0",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/redis": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "dotenv": "^17.4.2",
-    "playwright-core": "1.58.1",
+    "playwright-core": "1.62.1",
     "redis": "^6.2.1",
     "zod": "^4.4.3"
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -161,11 +161,12 @@ class BrowserWorker {
             await this.listenForCommands();
 
             const browserConfig = {
+                host: '0.0.0.0',
                 port: this.config.server.port,
                 headless: this.config.server.headless,
                 wsPath: `/playwright/${this.workerId}`,
             };
-            
+
             switch (this.config.server.browserType) {
                 case 'chromium':
                     this.browserServer = await chromium.launchServer({
@@ -186,7 +187,10 @@ class BrowserWorker {
             const wsEndpoint = this.browserServer.wsEndpoint();
             this.internalEndpoint = wsEndpoint;
             if (this.config.server.privateHostname) {
-                this.internalEndpoint = wsEndpoint.replace(/ws:\/\/127\.0\.0\.1|ws:\/\/localhost/, `ws://${this.config.server.privateHostname}`);
+                this.internalEndpoint = wsEndpoint.replace(
+                    /ws:\/\/(?:0\.0\.0\.0|127\.0\.0\.1|localhost|\[::1\])/,
+                    `ws://${this.config.server.privateHostname}`
+                );
             }
 
             this.logger.debug('Browser server launched', { endpoint: this.internalEndpoint });


### PR DESCRIPTION
## Summary

- upgrade `playwright-core` and the official runtime image together from 1.58.1 to 1.62.1
- bind browser servers to the container network explicitly, matching Playwright 1.62's loopback-only default
- update Firefox and WebKit connection examples for the explicit root path required before query parameters

## Validation

- `npm --prefix worker run typecheck`
- `node scripts/check-playwright-version.js`
- built all local Docker images
- smoke-tested Chromium, Firefox, and WebKit through the proxy
- `COMPOSE_OVERRIDE_FILE=/tmp/playwright-distributed-security-override.yaml WS_ENDPOINT=ws://127.0.0.1:18080 scripts/test/worker-redis-resilience.sh`
- `npm audit --json` (0 vulnerabilities)