### PR TITLE
chore(proxy): update Go to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache-dependency-path: proxy/go.sum
 
       - name: Vet proxy

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.24 AS build
+FROM golang:1.26.6-alpine3.24 AS build
 
 WORKDIR /build
 


### PR DESCRIPTION
## Behavior change

None in the proxy itself. Go 1.26.6 fixes three standard-library vulnerabilities that govulncheck reports as reachable from the proxy: [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) (crypto/tls), [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) (net/http), and [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) (encoding/asn1). These findings failed the `checks / proxy-tests` job in the v0.3.0 release run ([31783178952](https://github.com/mbroton/playwright-distributed/actions/runs/31783178952)).

## Configuration impact

- `proxy/Dockerfile` builder image: `golang:1.26.5-alpine3.24` → `golang:1.26.6-alpine3.24` (image verified to exist).
- `ci.yml` setup-go: `1.26.5` → `1.26.6`, so the scan and the shipped binary use the same toolchain.

## Verification

- This PR's own `proxy-tests` job runs govulncheck with Go 1.26.6 and is the authoritative check that the findings clear.
- `go vet` and `go test -race ./...` passed locally on this commit.