### PR TITLE
fix(ci): pull the redis image before the release smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,13 @@ jobs:
           cache-from: type=gha,scope=worker
           tags: ghcr.io/${{ github.repository }}/worker:latest
 
+      # `--pull never` guards the ghcr images: the deployment must use the
+      # images built above, never ones already published. It also blocks
+      # third-party images, which a fresh runner does not have, so pull
+      # those explicitly first.
+      - name: Pull images not built from this repository
+        run: docker compose -f docker-compose.yaml pull redis
+
       - name: Start the documented deployment
         run: docker compose -f docker-compose.yaml up -d --pull never
 


### PR DESCRIPTION
## Behavior change

The release `build` job starts `docker-compose.yaml` with `--pull never` so the smoke test can only use the images built in the same job — never images already published. That flag also blocks third-party images, and a fresh runner has no `redis:8.0`, so the deployment failed with `No such image: redis:8.0` in the v0.3.0 release run ([31783178952](https://github.com/mbroton/playwright-distributed/actions/runs/31783178952)) — the first run to exercise this step. The #99 rehearsal passed locally because that machine already had the redis image cached.

This adds one step that pulls the third-party image explicitly before the `up`. The ghcr images stay guarded by `--pull never`.

## Configuration impact

None. One added step in `release.yml`; no inputs or secrets change.

## Verification

- `docker compose -f docker-compose.yaml pull redis` pulls exactly the redis service image; verified locally that the command targets only that service.
- The full path is only exercised by a tag run; the next release tag validates it (the same situation #99 documented for its own changes).