### PR TITLE
fix(ci): move shared dependabot options to the multi-ecosystem group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ multi-ecosystem-groups:
   playwright:
     schedule:
       interval: weekly
+    # Shared options must live on the group, not on its member updates;
+    # Dependabot rejects the whole config otherwise.
+    open-pull-requests-limit: 10
     labels: ["dependencies", "worker"]
     assignees: ["mbroton"]
     commit-message:
@@ -16,9 +19,6 @@ updates:
     directory: "/worker"
     patterns: ["playwright-core"]
     multi-ecosystem-group: playwright
-    open-pull-requests-limit: 10
-    labels: ["dependencies", "worker"]
-    assignees: ["mbroton"]
   - package-ecosystem: docker
     directory: "/worker"
     patterns: ["playwright"]


### PR DESCRIPTION
Dependabot rejects the whole config since #108 landed:

> "open-pull-requests-limit" should only be set on the associated
> multi-ecosystem group, not directly on updates that are part of a
> multi-ecosystem update group.

The offending line predates #108 — Dependabot only re-parses the file when it
changes, so adding the gomod entry surfaced the latent violation. This moves
`open-pull-requests-limit` onto the `playwright` group and drops the member
entry's duplicated `labels`/`assignees` (the group already sets both). The
standalone gomod entry keeps its own options, which is allowed.

No behavior change intended: same limit, labels, and assignees.

Verification: YAML parses; the config change only takes effect on the default
branch, so Dependabot re-validates after merge — watch the Dependabot check on
the merge commit.