### PR TITLE
feat(bench): add reproducible latency and throughput benchmarks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
     directory: "/worker"
     patterns: ["playwright"]
     multi-ecosystem-group: playwright
+  - package-ecosystem: npm
+    directory: "/bench"
+    patterns: ["playwright"]
+    multi-ecosystem-group: playwright
   - package-ecosystem: gomod
     directory: "/server"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ multi-ecosystem-groups:
     # Shared options must live on the group, not on its member updates;
     # Dependabot rejects the whole config otherwise.
     open-pull-requests-limit: 10
-    labels: ["dependencies", "worker"]
+    labels: ["dependencies"]
     assignees: ["mbroton"]
     commit-message:
       prefix: "chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Verify Playwright versions stay in sync
         run: node scripts/check-playwright-version.js
 
+      - name: Verify bench lockfile and scripts
+        working-directory: bench
+        run: |
+          npm ci
+          node --check lib.js
+          node --check time-to-first-page.js
+          node --check throughput.js
+
   worker-checks:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,9 @@ API) and a TypeScript Playwright worker.
 
 - Preserve the server/worker boundary unless the task explicitly changes the
   architecture.
-- Keep `worker/package.json`'s `playwright-core` version equal to the Playwright
-  image version in `worker/Dockerfile`. Update them together.
+- Keep `worker/package.json`'s `playwright-core` version and
+  `bench/package.json`'s `playwright` version equal to the Playwright image
+  version in `worker/Dockerfile`. Update them together.
 - Worker code uses ES modules. Keep explicit `.js` suffixes in local imports.
 - Avoid unrelated refactors, dependencies, or repository-wide tooling changes.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -3,15 +3,22 @@
 Two reproducible benchmarks measure what the project optimizes for:
 
 1. **Time-to-first-page** (`time-to-first-page.js`) — how long a client waits
-   between asking for a browser and having a page ready. Compares
-   `chromium.connect()` against the grid (warm browser, no launch) with plain
-   `chromium.launch()` on the same machine (cold launch, the default everyone
-   starts from).
+   between asking for a browser and having a page ready. Three baselines:
+   - `grid connect()` — a fresh isolated session from the grid;
+   - `local launch()` — a browser launched per task on the same machine;
+   - `local reused browser` — a context on an already-running local browser,
+     the way `@playwright/test` reuses a worker's browser.
+
+   The honest reading: a warm local browser is the latency floor, and the
+   grid does not try to beat it. What the numbers show is the price of the
+   grid — a few milliseconds of relay overhead for isolation, one shared
+   endpoint, and fleet capacity.
 2. **Throughput** (`throughput.js`) — complete sessions per second at a fixed
-   client concurrency. Two modes:
-   - **Saturation**: unlimited workers on one machine, showing that the
-     coordination layer is not the bottleneck (the machine's CPU is).
-   - **Scaling**: each worker pinned to a fixed CPU budget (`WORKER_CPUS`),
+   client concurrency. A session is connect → context → page → goto → close,
+   timed end to end. Two modes:
+   - **Saturation**: unlimited workers on one machine, showing where a single
+     machine tops out end to end.
+   - **Scaling**: each worker capped at a fixed CPU budget (`WORKER_CPUS`),
      so adding a worker simulates adding a fixed-size node. Run against 1, 2,
      and 3 workers to show the throughput curve.
 
@@ -21,71 +28,101 @@ latency and scale-out, not browser memory use.
 
 ## Setup
 
+Requires Node.js 20+ and Docker.
+
 ```bash
 cd bench
 npm ci
-npx playwright install chromium   # local-launch baseline needs a local browser
+npx playwright install --with-deps chromium   # local baselines need a local browser
 ```
 
 The pinned `playwright` version must match the grid's worker version
-(`scripts/check-playwright-version.js` enforces this).
+(`scripts/check-playwright-version.js` enforces this; the server routes
+clients to version-matched workers).
 
 ## Run
 
-All commands below run from `bench/`. Start the grid:
+All commands run from `bench/`. Start every measured sequence from a fresh
+stack — `down -v` also removes postgres's anonymous volume, so no session
+rows or per-worker counters leak between sequences:
 
 ```bash
-docker compose -f ../bench/docker-compose.yaml up -d --build --scale worker=1
+docker compose down -v
 ```
 
-Wait until `curl -s localhost:8080/v1/capacity` reports the expected workers,
-then:
+**Latency** (1 worker, no CPU cap):
 
 ```bash
-# Latency: grid connect vs local launch
-node time-to-first-page.js
-
-# Throughput, saturation mode: how much one machine serves end to end
-# (concurrency = workers x MAX_SLOTS, 5 per worker)
-docker compose -f ../bench/docker-compose.yaml up -d --scale worker=3
-node throughput.js --sessions 600 --concurrency 15 --label "saturation"
-
-# Throughput, scaling mode: fixed-size workers, growing fleet
-export WORKER_CPUS=2
-docker compose -f ../bench/docker-compose.yaml up -d --scale worker=1
-node throughput.js --sessions 150 --concurrency 5  --label "1 worker"
-docker compose -f ../bench/docker-compose.yaml up -d --scale worker=2
-node throughput.js --sessions 200 --concurrency 10 --label "2 workers"
-docker compose -f ../bench/docker-compose.yaml up -d --scale worker=3
-node throughput.js --sessions 300 --concurrency 15 --label "3 workers"
+docker compose up -d --build --scale worker=1
+node time-to-first-page.js --expect-workers 1
 ```
 
-Between scaling steps, wait until `/v1/capacity` shows the new worker count.
+**Throughput, saturation mode** (unlimited workers, concurrency = workers x
+MAX_SLOTS, 5 per worker). Run it three times and publish the median:
 
-Options: `--endpoint` (default `ws://127.0.0.1:8080`), `--iterations`,
-`--warmup`, `--mode grid|local|both` for latency; `--sessions`,
-`--concurrency`, `--label` for throughput.
+```bash
+docker compose down -v && docker compose up -d --scale worker=3
+node throughput.js --sessions 1500 --concurrency 15 --expect-workers 3 --label saturation
+```
+
+While a saturation run is in flight, capture per-container CPU in another
+shell to attribute the load:
+
+```bash
+docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}'
+```
+
+**Throughput, scaling mode** (fixed-size workers, growing fleet). Fresh stack
+per point, three runs per point, publish the median:
+
+```bash
+docker compose down -v && WORKER_CPUS=2 docker compose up -d --scale worker=1
+node throughput.js --sessions 500  --concurrency 5  --expect-workers 1 --label "1 worker"
+
+docker compose down -v && WORKER_CPUS=2 docker compose up -d --scale worker=2
+node throughput.js --sessions 1000 --concurrency 10 --expect-workers 2 --label "2 workers"
+
+docker compose down -v && WORKER_CPUS=2 docker compose up -d --scale worker=3
+node throughput.js --sessions 1500 --concurrency 15 --expect-workers 3 --label "3 workers"
+```
+
+`WORKER_CPUS` is passed inline on purpose: exporting it would silently cap
+the saturation runs too.
+
+Script options: `--endpoint` (default `ws://127.0.0.1:8080`), `--iterations`,
+`--warmup`, `--mode all|grid|local|local-reused`, `--expect-workers` for
+latency; `--sessions`, `--concurrency`, `--warmup` (sessions, default 2x
+concurrency), `--expect-workers`, `--label` for throughput.
 
 ## Methodology notes
 
-- Keep `--concurrency` at or below capacity (workers x `MAX_SLOTS`), so the
-  result measures service rate rather than admission-control queueing.
+- `--expect-workers` polls `/v1/capacity` until the fleet has registered and
+  refuses to run when `--concurrency` exceeds free slots, so the result
+  measures service rate rather than admission-control queueing.
+- Throughput runs discard a warmup phase (default 2x concurrency sessions)
+  so ramp costs — cold client, first context on each worker, the scheduler
+  filling slots — stay out of the measured window.
+- The per-session timer includes `browser.close()`: a slot is busy until the
+  session is fully torn down, so anything less would overstate capacity.
 - The bench stack disables worker recycling (`MAX_LIFETIME_SESSIONS=0`; the
   production default drains a worker after 50 lifetime sessions). With
   recycling on, the throughput number would mostly measure how fast your
   container runtime restarts workers. In a real multi-worker fleet, staggered
   selection spreads recycles out, so the fleet keeps serving while one worker
   restarts.
-- Everything (client, server, workers, postgres) shares one machine in this
-  setup, so the processes compete for CPU. That deflates grid numbers rather
-  than inflating them: published numbers include the machine's specs, and a
-  client on a separate host will only look better.
+- The bench stack runs in unauthenticated bootstrap mode (zero API keys),
+  like the local compose stack. With authentication enabled the server also
+  verifies the key hash on every request — roughly one extra indexed lookup —
+  which these numbers do not include.
 - The scaling mode exists because stacking unlimited workers on one machine
   cannot show scale-out: they all share the same CPUs, so throughput flattens
-  at the machine's limit no matter how many workers run. Pinning each worker
-  to a fixed CPU budget makes "add a worker" mean "add capacity", which is
+  at the machine's limit no matter how many workers run. Capping each worker
+  at a fixed CPU budget makes "add a worker" mean "add capacity", which is
   what adding a node does in a real deployment. It stays honest only while
   the machine has spare CPUs for the client, server, and postgres.
+- Everything (client, server, workers, postgres) shares one machine in this
+  setup, so the processes compete for CPU. That deflates grid numbers rather
+  than inflating them: a client on a separate host will only look better.
 - Report the hardware next to any published numbers: CPU count, RAM, and
   whether other load was present.
 
@@ -93,27 +130,32 @@ Options: `--endpoint` (default `ws://127.0.0.1:8080`), `--iterations`,
 
 Machine: AMD Ryzen 5 5600 (6 cores / 12 threads), 30 GB RAM, Linux. Client,
 server, postgres, and all workers colocated; desktop background load present.
-Playwright 1.62.1.
+Playwright 1.62.1. Throughput numbers are the median of three runs.
 
 Time-to-first-page (30 iterations):
 
-|                  | min | p50 | p95 | max |
-|------------------|-----|-----|-----|-----|
-| grid `connect()` | 32ms | 34ms | 38ms | 40ms |
-| local `launch()` | 77ms | 83ms | 89ms | 90ms |
+|                      | min | p50 | p95 | max |
+|----------------------|-----|-----|-----|-----|
+| grid `connect()`     | 31ms | 35ms | 37ms | 40ms |
+| local `launch()`     | 76ms | 86ms | 91ms | 91ms |
+| local reused browser | 23ms | 25ms | 27ms | 28ms |
+
+Reading: a fresh isolated grid session costs ~10ms more than a context on an
+already-warm local browser, and ~50ms less than launching a browser per task.
 
 Throughput, saturation mode (3 unlimited workers, concurrency 15):
-**95 sessions/s** (5,697 sessions/min, 600/600 completed) with the machine at
-~95% CPU — the browsers consume the machine; the grid machinery does not.
+**98 sessions/s** (5,881 sessions/min; runs: 95.2 / 98.0 / 98.9, 4500/4500
+completed). Per-container CPU mid-run: each worker ~320%, server 33%,
+postgres 33% — the browsers consume the machine; the coordination layer uses
+well under one core.
 
 Throughput, scaling mode (`WORKER_CPUS=2`, concurrency = 5 per worker):
 
 | workers | sessions/s | vs 1 worker | session p50 |
 |---------|-----------|-------------|-------------|
-| 1 | 25.2 | 1.0x | 198ms |
-| 2 | 46.5 | 1.8x | 203ms |
-| 3 | 66.6 | 2.6x | 210ms |
+| 1 | 25.0 | 1.0x | 200ms |
+| 2 | 47.2 | 1.9x | 204ms |
+| 3 | 74.4 | 3.0x | 200ms |
 
-Per-session latency stays flat as the fleet grows; the sub-linear tail at 3
-workers is the shared client/server/postgres competing for the remaining
-cores of a 6-core machine.
+Throughput grows linearly with workers and per-session latency stays flat.
+(Per-run spread was under 4% at every point.)

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,119 @@
+# Benchmarks
+
+Two reproducible benchmarks measure what the project optimizes for:
+
+1. **Time-to-first-page** (`time-to-first-page.js`) — how long a client waits
+   between asking for a browser and having a page ready. Compares
+   `chromium.connect()` against the grid (warm browser, no launch) with plain
+   `chromium.launch()` on the same machine (cold launch, the default everyone
+   starts from).
+2. **Throughput** (`throughput.js`) — complete sessions per second at a fixed
+   client concurrency. Two modes:
+   - **Saturation**: unlimited workers on one machine, showing that the
+     coordination layer is not the bottleneck (the machine's CPU is).
+   - **Scaling**: each worker pinned to a fixed CPU budget (`WORKER_CPUS`),
+     so adding a worker simulates adding a fixed-size node. Run against 1, 2,
+     and 3 workers to show the throughput curve.
+
+Both use a `data:` URL page, so no external network time pollutes the numbers.
+There is deliberately no memory benchmark: the project optimizes connect
+latency and scale-out, not browser memory use.
+
+## Setup
+
+```bash
+cd bench
+npm ci
+npx playwright install chromium   # local-launch baseline needs a local browser
+```
+
+The pinned `playwright` version must match the grid's worker version
+(`scripts/check-playwright-version.js` enforces this).
+
+## Run
+
+All commands below run from `bench/`. Start the grid:
+
+```bash
+docker compose -f ../bench/docker-compose.yaml up -d --build --scale worker=1
+```
+
+Wait until `curl -s localhost:8080/v1/capacity` reports the expected workers,
+then:
+
+```bash
+# Latency: grid connect vs local launch
+node time-to-first-page.js
+
+# Throughput, saturation mode: how much one machine serves end to end
+# (concurrency = workers x MAX_SLOTS, 5 per worker)
+docker compose -f ../bench/docker-compose.yaml up -d --scale worker=3
+node throughput.js --sessions 600 --concurrency 15 --label "saturation"
+
+# Throughput, scaling mode: fixed-size workers, growing fleet
+export WORKER_CPUS=2
+docker compose -f ../bench/docker-compose.yaml up -d --scale worker=1
+node throughput.js --sessions 150 --concurrency 5  --label "1 worker"
+docker compose -f ../bench/docker-compose.yaml up -d --scale worker=2
+node throughput.js --sessions 200 --concurrency 10 --label "2 workers"
+docker compose -f ../bench/docker-compose.yaml up -d --scale worker=3
+node throughput.js --sessions 300 --concurrency 15 --label "3 workers"
+```
+
+Between scaling steps, wait until `/v1/capacity` shows the new worker count.
+
+Options: `--endpoint` (default `ws://127.0.0.1:8080`), `--iterations`,
+`--warmup`, `--mode grid|local|both` for latency; `--sessions`,
+`--concurrency`, `--label` for throughput.
+
+## Methodology notes
+
+- Keep `--concurrency` at or below capacity (workers x `MAX_SLOTS`), so the
+  result measures service rate rather than admission-control queueing.
+- The bench stack disables worker recycling (`MAX_LIFETIME_SESSIONS=0`; the
+  production default drains a worker after 50 lifetime sessions). With
+  recycling on, the throughput number would mostly measure how fast your
+  container runtime restarts workers. In a real multi-worker fleet, staggered
+  selection spreads recycles out, so the fleet keeps serving while one worker
+  restarts.
+- Everything (client, server, workers, postgres) shares one machine in this
+  setup, so the processes compete for CPU. That deflates grid numbers rather
+  than inflating them: published numbers include the machine's specs, and a
+  client on a separate host will only look better.
+- The scaling mode exists because stacking unlimited workers on one machine
+  cannot show scale-out: they all share the same CPUs, so throughput flattens
+  at the machine's limit no matter how many workers run. Pinning each worker
+  to a fixed CPU budget makes "add a worker" mean "add capacity", which is
+  what adding a node does in a real deployment. It stays honest only while
+  the machine has spare CPUs for the client, server, and postgres.
+- Report the hardware next to any published numbers: CPU count, RAM, and
+  whether other load was present.
+
+## Results (2026-08-21)
+
+Machine: AMD Ryzen 5 5600 (6 cores / 12 threads), 30 GB RAM, Linux. Client,
+server, postgres, and all workers colocated; desktop background load present.
+Playwright 1.62.1.
+
+Time-to-first-page (30 iterations):
+
+|                  | min | p50 | p95 | max |
+|------------------|-----|-----|-----|-----|
+| grid `connect()` | 32ms | 34ms | 38ms | 40ms |
+| local `launch()` | 77ms | 83ms | 89ms | 90ms |
+
+Throughput, saturation mode (3 unlimited workers, concurrency 15):
+**95 sessions/s** (5,697 sessions/min, 600/600 completed) with the machine at
+~95% CPU — the browsers consume the machine; the grid machinery does not.
+
+Throughput, scaling mode (`WORKER_CPUS=2`, concurrency = 5 per worker):
+
+| workers | sessions/s | vs 1 worker | session p50 |
+|---------|-----------|-------------|-------------|
+| 1 | 25.2 | 1.0x | 198ms |
+| 2 | 46.5 | 1.8x | 203ms |
+| 3 | 66.6 | 2.6x | 210ms |
+
+Per-session latency stays flat as the fleet grows; the sub-linear tail at 3
+workers is the shared client/server/postgres competing for the remaining
+cores of a 6-core machine.

--- a/bench/README.md
+++ b/bench/README.md
@@ -69,8 +69,8 @@ Node process and can become the ceiling on small machines):
 
 ```bash
 docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}'
-pidstat -p "$(pgrep -f throughput.js)" 5 1
-curl -s localhost:8080/v1/capacity   # "queued" must stay 0 mid-run
+ps -o %cpu= -p "$(pgrep -fn throughput.js)"
+curl -s localhost:8080/v1/capacity   # "queued" should stay at or near 0
 ```
 
 **Throughput, scaling mode** (fixed-size workers, growing fleet). Fresh stack
@@ -97,9 +97,11 @@ concurrency), `--expect-workers`, `--label` for throughput.
 
 ## Methodology notes
 
-- `--expect-workers` polls `/v1/capacity` until the fleet has registered and
-  refuses to run when `--concurrency` exceeds free slots, so the result
-  measures service rate rather than admission-control queueing.
+- `--expect-workers` polls `/v1/capacity` until *exactly* that many idle
+  workers of the benchmarked browser have registered (extra or leftover
+  workers fail the gate too — hence the fresh stack per point), and refuses
+  to run when `--concurrency` exceeds free slots. It does not check the
+  concurrency-equals-capacity rule below; that is on the operator.
 - Concurrency must equal capacity (workers x MAX_SLOTS) in scaling runs, not
   just stay below it: the scheduler deliberately packs the busiest worker
   first (that staggers recycling in production), so at partial concurrency

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,8 +15,8 @@ Reproducible benchmarks for the grid:
 2. **Throughput** (`throughput.js`) — complete sessions per second at a fixed
    client concurrency. A session is connect → context → page → goto → close,
    timed end to end. Two modes:
-   - **Saturation**: unlimited workers on one machine, showing where a single
-     machine tops out end to end.
+   - **Saturation**: CPU-uncapped workers on one machine, showing where a
+     single machine tops out end to end.
    - **Scaling**: each worker capped at a fixed CPU budget (`WORKER_CPUS`),
      so adding a worker simulates adding a fixed-size node. Run against 1, 2,
      and 3 workers to show the throughput curve.
@@ -55,8 +55,8 @@ docker compose up -d --build --scale worker=1
 node time-to-first-page.js --expect-workers 1
 ```
 
-**Throughput, saturation mode** (unlimited workers, concurrency = workers x
-MAX_SLOTS, 5 per worker). Run it three times and publish the median:
+**Throughput, saturation mode** (CPU-uncapped workers, concurrency = workers
+x MAX_SLOTS, 5 per worker). Run it three times and publish the median:
 
 ```bash
 docker compose down -v && docker compose up -d --scale worker=3
@@ -64,10 +64,13 @@ node throughput.js --sessions 1500 --concurrency 15 --expect-workers 3 --label s
 ```
 
 While a saturation run is in flight, capture per-container CPU in another
-shell to attribute the load:
+shell to attribute the load, and the bench client's own CPU (it is a single
+Node process and can become the ceiling on small machines):
 
 ```bash
 docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}'
+pidstat -p "$(pgrep -f throughput.js)" 5 1
+curl -s localhost:8080/v1/capacity   # "queued" must stay 0 mid-run
 ```
 
 **Throughput, scaling mode** (fixed-size workers, growing fleet). Fresh stack
@@ -97,21 +100,29 @@ concurrency), `--expect-workers`, `--label` for throughput.
 - `--expect-workers` polls `/v1/capacity` until the fleet has registered and
   refuses to run when `--concurrency` exceeds free slots, so the result
   measures service rate rather than admission-control queueing.
-- Throughput runs discard a warmup phase (default 2x concurrency sessions)
-  so ramp costs — cold client, first context on each worker, the scheduler
-  filling slots — stay out of the measured window.
+- Concurrency must equal capacity (workers x MAX_SLOTS) in scaling runs, not
+  just stay below it: the scheduler deliberately packs the busiest worker
+  first (that staggers recycling in production), so at partial concurrency
+  added workers sit idle and the curve looks flat even though capacity grew.
+- Fresh stacks per point are the main ramp control; the short warmup phase
+  (default 2x concurrency sessions, discarded) additionally keeps cold-client
+  and first-context costs out of the measured window.
+- Sessions are isolated browser contexts, not browser processes: a worker
+  multiplexes up to MAX_SLOTS sessions onto one browser process, which is the
+  same isolation level as the `local reused browser` variant. Keep this in
+  mind when comparing against per-session-process designs.
 - The per-session timer includes `browser.close()`: a slot is busy until the
   session is fully torn down, so anything less would overstate capacity.
 - The bench stack disables worker recycling (`MAX_LIFETIME_SESSIONS=0`; the
   production default drains a worker after 50 lifetime sessions). With
-  recycling on, the throughput number would mostly measure how fast your
-  container runtime restarts workers. In a real multi-worker fleet, staggered
-  selection spreads recycles out, so the fleet keeps serving while one worker
-  restarts.
+  recycling on, the throughput number would also include worker restart time,
+  which depends on the container runtime, not on the grid.
 - The bench stack runs in unauthenticated bootstrap mode (zero API keys),
   like the local compose stack. With authentication enabled the server also
-  verifies the key hash on every request — roughly one extra indexed lookup —
-  which these numbers do not include.
+  verifies the key hash on every request (an indexed lookup, plus a last-used
+  timestamp update throttled to once per minute), which these numbers do not
+  include. An authenticated grid can still be benched:
+  `--endpoint 'ws://host:8080/?token=pwd_...'`.
 - The scaling mode exists because stacking unlimited workers on one machine
   cannot show scale-out: they all share the same CPUs, so throughput flattens
   at the machine's limit no matter how many workers run. Capping each worker

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,18 +1,17 @@
 # Benchmarks
 
-Two reproducible benchmarks measure what the project optimizes for:
+Reproducible benchmarks for the grid:
 
-1. **Time-to-first-page** (`time-to-first-page.js`) — how long a client waits
-   between asking for a browser and having a page ready. Three baselines:
+1. **Time-to-first-page** (`time-to-first-page.js`) — time from requesting a
+   browser to a page being ready for use. Three variants:
    - `grid connect()` — a fresh isolated session from the grid;
    - `local launch()` — a browser launched per task on the same machine;
-   - `local reused browser` — a context on an already-running local browser,
-     the way `@playwright/test` reuses a worker's browser.
+   - `local reused browser` — a new context on an already-running local
+     browser, the way `@playwright/test` reuses a worker's browser.
 
-   The honest reading: a warm local browser is the latency floor, and the
-   grid does not try to beat it. What the numbers show is the price of the
-   grid — a few milliseconds of relay overhead for isolation, one shared
-   endpoint, and fleet capacity.
+   The two local variants bound the comparison: `local reused browser` is
+   the latency floor on the same machine, and the difference between it and
+   `grid connect()` is the grid's relay and scheduling overhead.
 2. **Throughput** (`throughput.js`) — complete sessions per second at a fixed
    client concurrency. A session is connect → context → page → goto → close,
    timed end to end. Two modes:
@@ -22,9 +21,8 @@ Two reproducible benchmarks measure what the project optimizes for:
      so adding a worker simulates adding a fixed-size node. Run against 1, 2,
      and 3 workers to show the throughput curve.
 
-Both use a `data:` URL page, so no external network time pollutes the numbers.
-There is deliberately no memory benchmark: the project optimizes connect
-latency and scale-out, not browser memory use.
+Both use a `data:` URL page, so no external network time pollutes the
+numbers.
 
 ## Setup
 
@@ -125,37 +123,3 @@ concurrency), `--expect-workers`, `--label` for throughput.
   than inflating them: a client on a separate host will only look better.
 - Report the hardware next to any published numbers: CPU count, RAM, and
   whether other load was present.
-
-## Results (2026-08-21)
-
-Machine: AMD Ryzen 5 5600 (6 cores / 12 threads), 30 GB RAM, Linux. Client,
-server, postgres, and all workers colocated; desktop background load present.
-Playwright 1.62.1. Throughput numbers are the median of three runs.
-
-Time-to-first-page (30 iterations):
-
-|                      | min | p50 | p95 | max |
-|----------------------|-----|-----|-----|-----|
-| grid `connect()`     | 31ms | 35ms | 37ms | 40ms |
-| local `launch()`     | 76ms | 86ms | 91ms | 91ms |
-| local reused browser | 23ms | 25ms | 27ms | 28ms |
-
-Reading: a fresh isolated grid session costs ~10ms more than a context on an
-already-warm local browser, and ~50ms less than launching a browser per task.
-
-Throughput, saturation mode (3 unlimited workers, concurrency 15):
-**98 sessions/s** (5,881 sessions/min; runs: 95.2 / 98.0 / 98.9, 4500/4500
-completed). Per-container CPU mid-run: each worker ~320%, server 33%,
-postgres 33% — the browsers consume the machine; the coordination layer uses
-well under one core.
-
-Throughput, scaling mode (`WORKER_CPUS=2`, concurrency = 5 per worker):
-
-| workers | sessions/s | vs 1 worker | session p50 |
-|---------|-----------|-------------|-------------|
-| 1 | 25.0 | 1.0x | 200ms |
-| 2 | 47.2 | 1.9x | 204ms |
-| 3 | 74.4 | 3.0x | 200ms |
-
-Throughput grows linearly with workers and per-session latency stays flat.
-(Per-run spread was under 4% at every point.)

--- a/bench/docker-compose.yaml
+++ b/bench/docker-compose.yaml
@@ -1,0 +1,62 @@
+# Benchmark stack: postgres + server + N identical chromium workers.
+# Scale the worker count per run:
+#   docker compose -f bench/docker-compose.yaml up -d --build --scale worker=3
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      - POSTGRES_USER=pwd
+      - POSTGRES_PASSWORD=pwd
+      - POSTGRES_DB=pwd
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pwd -d pwd"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  server:
+    build:
+      context: ../server
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_URL=postgres://pwd:pwd@postgres:5432/pwd?sslmode=disable
+      # Worker recycling (default: drain after 50 lifetime sessions) is
+      # disabled so throughput measures the grid's service rate, not the
+      # container runtime's restart latency. See README.md before changing.
+      - MAX_LIFETIME_SESSIONS=0
+    ports:
+      - "127.0.0.1:8080:8080"
+    stop_grace_period: 60s
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/healthz"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  worker:
+    build:
+      context: ../worker
+      dockerfile: Dockerfile
+    init: true
+    # Scaling runs pin each worker to a fixed CPU budget so that adding
+    # workers simulates adding fixed-size nodes (see README.md). 0 = no limit.
+    cpus: ${WORKER_CPUS:-0}
+    security_opt:
+      - seccomp=../worker/seccomp_profile.json
+    shm_size: "1gb"
+    stop_grace_period: 60s
+    environment:
+      - SERVER_URL=http://server:8080
+      - BROWSER_TYPE=chromium
+      - PORT=3131
+      - LOG_FORMAT=text
+      - DRAIN_TIMEOUT=30
+      - MAX_SLOTS=5
+    depends_on:
+      server:
+        condition: service_healthy
+    # Recycled workers exit cleanly by design and must come back.
+    restart: unless-stopped

--- a/bench/docker-compose.yaml
+++ b/bench/docker-compose.yaml
@@ -1,6 +1,8 @@
 # Benchmark stack: postgres + server + N identical chromium workers.
-# Scale the worker count per run:
-#   docker compose -f bench/docker-compose.yaml up -d --build --scale worker=3
+# Scale the worker count per run (from bench/):
+#   docker compose up -d --build --scale worker=3
+# The server runs in unauthenticated bootstrap mode (zero API keys), like
+# docker-compose.local.yaml. Do not use it on a public network.
 services:
   postgres:
     image: postgres:18-alpine
@@ -58,5 +60,6 @@ services:
     depends_on:
       server:
         condition: service_healthy
-    # Recycled workers exit cleanly by design and must come back.
+    # Workers exit on fatal errors by design and rely on the restart policy
+    # to come back.
     restart: unless-stopped

--- a/bench/lib.js
+++ b/bench/lib.js
@@ -77,6 +77,8 @@ export async function withDeadline(promise, ms, label) {
   }
 }
 
+class CapacityAuthError extends Error {}
+
 // Polls /v1/capacity (derived from the ws endpoint) until exactly the
 // expected number of workers for the benchmarked browser has registered and
 // is idle, then verifies they have enough slots for the run. Exact count,
@@ -94,24 +96,25 @@ export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots,
 
   const deadline = Date.now() + 120_000;
   let entry;
+  let lastCapacity;
   for (;;) {
     try {
       const response = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
       if (response.status === 401 || response.status === 403) {
-        throw new Error(
-          `Capacity check got HTTP ${response.status}: the server requires an API key. ` +
-            "Pass it in the endpoint: --endpoint 'ws://host:8080/?token=pwd_...'"
+        throw new CapacityAuthError(
+          `Capacity check got HTTP ${response.status}: missing or rejected API key. ` +
+            "Pass a valid one in the endpoint: --endpoint 'ws://host:8080/?token=pwd_...'"
         );
       }
       if (response.ok) {
-        const capacity = await response.json();
-        entry = capacity.browsers.find((candidate) => candidate.browser === browser);
+        lastCapacity = await response.json();
+        entry = lastCapacity.browsers.find((candidate) => candidate.browser === browser);
         if (entry && entry.workers === expectedWorkers && entry.active_sessions === 0) {
           break;
         }
       }
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith('Capacity check got HTTP')) {
+      if (error instanceof CapacityAuthError) {
         throw error;
       }
       // Server may still be starting; keep polling until the deadline.
@@ -119,7 +122,7 @@ export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots,
     if (Date.now() > deadline) {
       throw new Error(
         `Timed out waiting for exactly ${expectedWorkers} idle ${browser} workers` +
-          (entry ? ` (last capacity: ${JSON.stringify(entry)})` : '')
+          (lastCapacity ? ` (last capacity: ${JSON.stringify(lastCapacity.browsers)})` : '')
       );
     }
     await new Promise((resolve) => setTimeout(resolve, 1_000));

--- a/bench/lib.js
+++ b/bench/lib.js
@@ -12,6 +12,9 @@ export function quantile(sortedValues, q) {
 }
 
 export function summarize(samples) {
+  if (samples.length === 0) {
+    throw new Error('summarize() needs at least one sample');
+  }
   const sorted = [...samples].sort((a, b) => a - b);
   const sum = sorted.reduce((total, value) => total + value, 0);
   return {
@@ -46,4 +49,67 @@ export function formatHeader() {
     cell('max') +
     cell('mean')
   );
+}
+
+export function parsePositiveInt(name, raw, { min = 1 } = {}) {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min) {
+    console.error(`${name} must be an integer >= ${min} (got "${raw}")`);
+    process.exit(1);
+  }
+  return value;
+}
+
+export async function withDeadline(promise, ms, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} exceeded ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Polls /v1/capacity (derived from the ws endpoint) until the expected worker
+// count has registered, then verifies the grid has enough slots for the run.
+export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots) {
+  const url = new URL(wsEndpoint);
+  url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+  url.pathname = '/v1/capacity';
+  url.search = '';
+
+  const deadline = Date.now() + 120_000;
+  let totals;
+  for (;;) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+      if (response.ok) {
+        totals = (await response.json()).totals;
+        if (totals.workers >= expectedWorkers && totals.active_sessions === 0) {
+          break;
+        }
+      }
+    } catch {
+      // Server may still be starting; keep polling until the deadline.
+    }
+    if (Date.now() > deadline) {
+      console.error(
+        `Timed out waiting for ${expectedWorkers} workers` +
+          (totals ? ` (last capacity: ${JSON.stringify(totals)})` : '')
+      );
+      process.exit(1);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  if (totals.available_slots < requiredSlots) {
+    console.error(
+      `Grid has ${totals.available_slots} slots but the run needs ${requiredSlots}; ` +
+        'lower --concurrency or add workers so the result measures service rate, not queueing'
+    );
+    process.exit(1);
+  }
 }

--- a/bench/lib.js
+++ b/bench/lib.js
@@ -1,0 +1,49 @@
+// Shared helpers for the benchmark scripts.
+
+export function quantile(sortedValues, q) {
+  if (sortedValues.length === 0) {
+    return NaN;
+  }
+  const position = (sortedValues.length - 1) * q;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  const weight = position - lower;
+  return sortedValues[lower] * (1 - weight) + sortedValues[upper] * weight;
+}
+
+export function summarize(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const sum = sorted.reduce((total, value) => total + value, 0);
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    p50: quantile(sorted, 0.5),
+    p95: quantile(sorted, 0.95),
+    max: sorted[sorted.length - 1],
+    mean: sum / sorted.length,
+  };
+}
+
+export function formatRow(label, stats) {
+  const cell = (value) => `${value.toFixed(0)}ms`.padStart(9);
+  return (
+    label.padEnd(24) +
+    cell(stats.min) +
+    cell(stats.p50) +
+    cell(stats.p95) +
+    cell(stats.max) +
+    cell(stats.mean)
+  );
+}
+
+export function formatHeader() {
+  const cell = (value) => value.padStart(9);
+  return (
+    ''.padEnd(24) +
+    cell('min') +
+    cell('p50') +
+    cell('p95') +
+    cell('max') +
+    cell('mean')
+  );
+}

--- a/bench/lib.js
+++ b/bench/lib.js
@@ -51,11 +51,14 @@ export function formatHeader() {
   );
 }
 
+// Thrown errors, not process.exit(): an exit() call can truncate output that
+// is still buffered in a pipe (node script | tee), losing the very message
+// that explains the failure. An uncaught throw is written synchronously and
+// still exits 1.
 export function parsePositiveInt(name, raw, { min = 1 } = {}) {
   const value = Number(raw);
   if (!Number.isInteger(value) || value < min) {
-    console.error(`${name} must be an integer >= ${min} (got "${raw}")`);
-    process.exit(1);
+    throw new Error(`${name} must be an integer >= ${min} (got "${raw}")`);
   }
   return value;
 }
@@ -83,13 +86,23 @@ export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots,
   const url = new URL(wsEndpoint);
   url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
   url.pathname = '/v1/capacity';
+  // An authenticated grid is benched by putting ?token=... in --endpoint;
+  // connect() sends it as-is and the capacity poll turns it into a bearer.
+  const token = url.searchParams.get('token');
   url.search = '';
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
   const deadline = Date.now() + 120_000;
   let entry;
   for (;;) {
     try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+      const response = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(
+          `Capacity check got HTTP ${response.status}: the server requires an API key. ` +
+            "Pass it in the endpoint: --endpoint 'ws://host:8080/?token=pwd_...'"
+        );
+      }
       if (response.ok) {
         const capacity = await response.json();
         entry = capacity.browsers.find((candidate) => candidate.browser === browser);
@@ -97,23 +110,24 @@ export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots,
           break;
         }
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Capacity check got HTTP')) {
+        throw error;
+      }
       // Server may still be starting; keep polling until the deadline.
     }
     if (Date.now() > deadline) {
-      console.error(
+      throw new Error(
         `Timed out waiting for exactly ${expectedWorkers} idle ${browser} workers` +
           (entry ? ` (last capacity: ${JSON.stringify(entry)})` : '')
       );
-      process.exit(1);
     }
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
   if (entry.available_slots < requiredSlots) {
-    console.error(
+    throw new Error(
       `${browser} workers have ${entry.available_slots} slots but the run needs ${requiredSlots}; ` +
         'lower --concurrency or add workers so the result measures service rate, not queueing'
     );
-    process.exit(1);
   }
 }

--- a/bench/lib.js
+++ b/bench/lib.js
@@ -74,22 +74,26 @@ export async function withDeadline(promise, ms, label) {
   }
 }
 
-// Polls /v1/capacity (derived from the ws endpoint) until the expected worker
-// count has registered, then verifies the grid has enough slots for the run.
-export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots) {
+// Polls /v1/capacity (derived from the ws endpoint) until exactly the
+// expected number of workers for the benchmarked browser has registered and
+// is idle, then verifies they have enough slots for the run. Exact count,
+// per browser: leftover workers from a previous stack, or workers of another
+// browser type, would silently change what the run measures.
+export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots, browser = 'chromium') {
   const url = new URL(wsEndpoint);
   url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
   url.pathname = '/v1/capacity';
   url.search = '';
 
   const deadline = Date.now() + 120_000;
-  let totals;
+  let entry;
   for (;;) {
     try {
       const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
       if (response.ok) {
-        totals = (await response.json()).totals;
-        if (totals.workers >= expectedWorkers && totals.active_sessions === 0) {
+        const capacity = await response.json();
+        entry = capacity.browsers.find((candidate) => candidate.browser === browser);
+        if (entry && entry.workers === expectedWorkers && entry.active_sessions === 0) {
           break;
         }
       }
@@ -98,16 +102,16 @@ export async function waitForWorkers(wsEndpoint, expectedWorkers, requiredSlots)
     }
     if (Date.now() > deadline) {
       console.error(
-        `Timed out waiting for ${expectedWorkers} workers` +
-          (totals ? ` (last capacity: ${JSON.stringify(totals)})` : '')
+        `Timed out waiting for exactly ${expectedWorkers} idle ${browser} workers` +
+          (entry ? ` (last capacity: ${JSON.stringify(entry)})` : '')
       );
       process.exit(1);
     }
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
-  if (totals.available_slots < requiredSlots) {
+  if (entry.available_slots < requiredSlots) {
     console.error(
-      `Grid has ${totals.available_slots} slots but the run needs ${requiredSlots}; ` +
+      `${browser} workers have ${entry.available_slots} slots but the run needs ${requiredSlots}; ` +
         'lower --concurrency or add workers so the result measures service rate, not queueing'
     );
     process.exit(1);

--- a/bench/package-lock.json
+++ b/bench/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "playwright-distributed-bench",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playwright-distributed-bench",
+      "dependencies": {
+        "playwright": "1.62.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/bench/package.json
+++ b/bench/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "playwright-distributed-bench",
+  "private": true,
+  "type": "module",
+  "description": "Reproducible benchmarks for playwright-distributed",
+  "scripts": {
+    "latency": "node time-to-first-page.js",
+    "throughput": "node throughput.js"
+  },
+  "dependencies": {
+    "playwright": "1.62.1"
+  }
+}

--- a/bench/package.json
+++ b/bench/package.json
@@ -2,6 +2,9 @@
   "name": "playwright-distributed-bench",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "Reproducible benchmarks for playwright-distributed",
   "scripts": {
     "latency": "node time-to-first-page.js",

--- a/bench/throughput.js
+++ b/bench/throughput.js
@@ -4,10 +4,12 @@
 // A session is connect -> newContext -> newPage -> goto -> close, and the
 // per-session timer covers all of it, including close. A discarded warmup
 // phase runs first so ramp costs (cold client, first context on each worker,
-// the scheduler filling slots) stay out of the measured window. Keep
-// --concurrency at or below the grid's capacity (workers x MAX_SLOTS) so the
-// result measures service rate, not admission-control queueing;
-// --expect-workers enforces that before the run starts.
+// the scheduler filling slots) stay out of the measured window. Run with
+// --concurrency equal to the grid's capacity (workers x MAX_SLOTS): above it
+// the result measures admission-control queueing, and below it the
+// busiest-first scheduler leaves added workers idle. --expect-workers
+// verifies registration and refuses concurrency above capacity; matching
+// capacity exactly is on the operator.
 
 import { parseArgs } from 'node:util';
 import { chromium } from 'playwright';

--- a/bench/throughput.js
+++ b/bench/throughput.js
@@ -1,0 +1,86 @@
+// Measures grid throughput: how many complete browser sessions the grid
+// serves per second at a fixed client concurrency.
+//
+// Each session is connect -> newContext -> newPage -> goto -> close. Keep
+// --concurrency at or below the grid's capacity (workers x MAX_SLOTS) so the
+// result measures service rate, not admission-control queueing.
+
+import { parseArgs } from 'node:util';
+import { chromium } from 'playwright';
+import { summarize, formatRow, formatHeader } from './lib.js';
+
+const PAGE_URL = 'data:text/html,<h1>bench</h1>';
+
+const { values: options } = parseArgs({
+  options: {
+    endpoint: { type: 'string', default: 'ws://127.0.0.1:8080' },
+    sessions: { type: 'string', default: '200' },
+    concurrency: { type: 'string', default: '5' },
+    label: { type: 'string', default: '' },
+  },
+});
+
+const totalSessions = Number.parseInt(options.sessions, 10);
+const concurrency = Number.parseInt(options.concurrency, 10);
+if (!Number.isInteger(totalSessions) || totalSessions < 1 || !Number.isInteger(concurrency) || concurrency < 1) {
+  console.error('--sessions and --concurrency must be integers >= 1');
+  process.exit(1);
+}
+
+async function runSession() {
+  const start = performance.now();
+  const browser = await chromium.connect(options.endpoint);
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(PAGE_URL);
+    return performance.now() - start;
+  } finally {
+    await browser.close();
+  }
+}
+
+const durations = [];
+const errors = [];
+let started = 0;
+
+async function clientLoop() {
+  while (started < totalSessions) {
+    started++;
+    try {
+      durations.push(await runSession());
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+}
+
+const benchStart = performance.now();
+await Promise.all(Array.from({ length: concurrency }, clientLoop));
+const elapsedSeconds = (performance.now() - benchStart) / 1000;
+
+const label = options.label ? ` [${options.label}]` : '';
+console.log(
+  `throughput${label}: ${totalSessions} sessions, concurrency ${concurrency}\n`
+);
+console.log(
+  `completed ${durations.length}/${totalSessions} in ${elapsedSeconds.toFixed(1)}s ` +
+    `= ${(durations.length / elapsedSeconds).toFixed(1)} sessions/s ` +
+    `(${((durations.length / elapsedSeconds) * 60).toFixed(0)} sessions/min)`
+);
+if (durations.length > 0) {
+  console.log('\nper-session duration:');
+  console.log(formatHeader());
+  console.log(formatRow('session', summarize(durations)));
+}
+if (errors.length > 0) {
+  const counts = new Map();
+  for (const message of errors) {
+    counts.set(message, (counts.get(message) ?? 0) + 1);
+  }
+  console.error(`\n${errors.length} sessions failed:`);
+  for (const [message, count] of counts) {
+    console.error(`  ${count}x ${message}`);
+  }
+  process.exit(1);
+}

--- a/bench/throughput.js
+++ b/bench/throughput.js
@@ -1,67 +1,104 @@
 // Measures grid throughput: how many complete browser sessions the grid
 // serves per second at a fixed client concurrency.
 //
-// Each session is connect -> newContext -> newPage -> goto -> close. Keep
+// A session is connect -> newContext -> newPage -> goto -> close, and the
+// per-session timer covers all of it, including close. A discarded warmup
+// phase runs first so ramp costs (cold client, first context on each worker,
+// the scheduler filling slots) stay out of the measured window. Keep
 // --concurrency at or below the grid's capacity (workers x MAX_SLOTS) so the
-// result measures service rate, not admission-control queueing.
+// result measures service rate, not admission-control queueing;
+// --expect-workers enforces that before the run starts.
 
 import { parseArgs } from 'node:util';
 import { chromium } from 'playwright';
-import { summarize, formatRow, formatHeader } from './lib.js';
+import {
+  summarize,
+  formatRow,
+  formatHeader,
+  parsePositiveInt,
+  withDeadline,
+  waitForWorkers,
+} from './lib.js';
 
 const PAGE_URL = 'data:text/html,<h1>bench</h1>';
+const connectTimeoutMs = 30_000;
+const closeTimeoutMs = 15_000;
 
 const { values: options } = parseArgs({
   options: {
     endpoint: { type: 'string', default: 'ws://127.0.0.1:8080' },
-    sessions: { type: 'string', default: '200' },
+    sessions: { type: 'string', default: '500' },
     concurrency: { type: 'string', default: '5' },
+    warmup: { type: 'string', default: '' }, // sessions; default 2 x concurrency
+    'expect-workers': { type: 'string', default: '' },
     label: { type: 'string', default: '' },
   },
 });
 
-const totalSessions = Number.parseInt(options.sessions, 10);
-const concurrency = Number.parseInt(options.concurrency, 10);
-if (!Number.isInteger(totalSessions) || totalSessions < 1 || !Number.isInteger(concurrency) || concurrency < 1) {
-  console.error('--sessions and --concurrency must be integers >= 1');
-  process.exit(1);
+const totalSessions = parsePositiveInt('--sessions', options.sessions);
+const concurrency = parsePositiveInt('--concurrency', options.concurrency);
+const warmupSessions = options.warmup
+  ? parsePositiveInt('--warmup', options.warmup, { min: 0 })
+  : 2 * concurrency;
+
+if (options['expect-workers']) {
+  const expectedWorkers = parsePositiveInt('--expect-workers', options['expect-workers']);
+  await waitForWorkers(options.endpoint, expectedWorkers, concurrency);
 }
 
 async function runSession() {
   const start = performance.now();
-  const browser = await chromium.connect(options.endpoint);
+  const browser = await chromium.connect(options.endpoint, { timeout: connectTimeoutMs });
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto(PAGE_URL);
-    return performance.now() - start;
   } finally {
-    await browser.close();
+    await withDeadline(browser.close(), closeTimeoutMs, 'browser.close()');
   }
+  return performance.now() - start;
 }
 
-const durations = [];
-const errors = [];
-let started = 0;
+async function runPhase(sessions, { record }) {
+  const durations = [];
+  const errors = [];
+  let started = 0;
+  let completed = 0;
 
-async function clientLoop() {
-  while (started < totalSessions) {
-    started++;
-    try {
-      durations.push(await runSession());
-    } catch (error) {
-      errors.push(error instanceof Error ? error.message : String(error));
+  async function clientLoop() {
+    while (started < sessions) {
+      started++;
+      try {
+        durations.push(await runSession());
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : String(error));
+      }
+      completed++;
+      if (record && completed % 100 === 0) {
+        process.stderr.write(`  ${completed}/${sessions}\n`);
+      }
     }
   }
+
+  const phaseStart = performance.now();
+  await Promise.all(Array.from({ length: Math.min(concurrency, sessions) }, clientLoop));
+  return { durations, errors, elapsedSeconds: (performance.now() - phaseStart) / 1000 };
 }
 
-const benchStart = performance.now();
-await Promise.all(Array.from({ length: concurrency }, clientLoop));
-const elapsedSeconds = (performance.now() - benchStart) / 1000;
+if (warmupSessions > 0) {
+  const warmup = await runPhase(warmupSessions, { record: false });
+  if (warmup.errors.length > 0) {
+    console.error(`${warmup.errors.length}/${warmupSessions} warmup sessions failed; not measuring a broken grid`);
+    process.exit(1);
+  }
+}
+
+const { durations, errors, elapsedSeconds } = await runPhase(totalSessions, { record: true });
 
 const label = options.label ? ` [${options.label}]` : '';
 console.log(
-  `throughput${label}: ${totalSessions} sessions, concurrency ${concurrency}\n`
+  `throughput${label}: ${totalSessions} sessions (after ${warmupSessions} warmup), ` +
+    `concurrency ${Math.min(concurrency, totalSessions)}\n`
 );
 console.log(
   `completed ${durations.length}/${totalSessions} in ${elapsedSeconds.toFixed(1)}s ` +
@@ -69,7 +106,7 @@ console.log(
     `(${((durations.length / elapsedSeconds) * 60).toFixed(0)} sessions/min)`
 );
 if (durations.length > 0) {
-  console.log('\nper-session duration:');
+  console.log('\nper-session duration (connect through close):');
   console.log(formatHeader());
   console.log(formatRow('session', summarize(durations)));
 }

--- a/bench/throughput.js
+++ b/bench/throughput.js
@@ -22,6 +22,7 @@ import {
 
 const PAGE_URL = 'data:text/html,<h1>bench</h1>';
 const connectTimeoutMs = 30_000;
+const sessionOpsTimeoutMs = 60_000;
 const closeTimeoutMs = 15_000;
 
 const { values: options } = parseArgs({
@@ -50,9 +51,16 @@ async function runSession() {
   const start = performance.now();
   const browser = await chromium.connect(options.endpoint, { timeout: connectTimeoutMs });
   try {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.goto(PAGE_URL);
+    // A wedged worker browser could stall any of these without a deadline.
+    await withDeadline(
+      (async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto(PAGE_URL);
+      })(),
+      sessionOpsTimeoutMs,
+      'session body'
+    );
   } finally {
     await withDeadline(browser.close(), closeTimeoutMs, 'browser.close()');
   }
@@ -88,8 +96,10 @@ async function runPhase(sessions, { record }) {
 if (warmupSessions > 0) {
   const warmup = await runPhase(warmupSessions, { record: false });
   if (warmup.errors.length > 0) {
-    console.error(`${warmup.errors.length}/${warmupSessions} warmup sessions failed; not measuring a broken grid`);
-    process.exit(1);
+    throw new Error(
+      `${warmup.errors.length}/${warmupSessions} warmup sessions failed; not measuring a broken grid ` +
+        `(first error: ${warmup.errors[0]})`
+    );
   }
 }
 
@@ -119,5 +129,6 @@ if (errors.length > 0) {
   for (const [message, count] of counts) {
     console.error(`  ${count}x ${message}`);
   }
-  process.exit(1);
+  // exitCode, not exit(): exit() can truncate output still buffered in a pipe.
+  process.exitCode = 1;
 }

--- a/bench/time-to-first-page.js
+++ b/bench/time-to-first-page.js
@@ -6,13 +6,14 @@
 //   local-reused: newContext -> newPage -> goto on one browser launched
 //                 upfront (how @playwright/test reuses a worker's browser)
 //
-// The three baselines answer different questions: "local" is the cost of a
-// browser per task; "local-reused" is the floor a warm local browser sets —
-// the grid does not try to beat it, it trades a few milliseconds of relay
-// overhead for isolation and fleet capacity. The page is a data: URL, so no
-// network time pollutes the numbers. Iterations run sequentially; warmup runs
-// are discarded (they pay one-time costs such as module loading and disk
-// cache).
+// The three variants bound the comparison: "local" is the cost of a browser
+// per task; "local-reused" is the floor a warm local browser sets, and the
+// gap between it and "grid" is the grid's relay and scheduling overhead.
+// Isolation is context-level in every variant — a worker multiplexes its
+// sessions as contexts on one browser process, like a local reused browser
+// does. The page is a data: URL, so no network time pollutes the numbers.
+// Iterations run sequentially; warmup runs are discarded (they pay one-time
+// costs such as module loading and disk cache).
 
 import { parseArgs } from 'node:util';
 import { chromium } from 'playwright';
@@ -27,6 +28,7 @@ import {
 
 const PAGE_URL = 'data:text/html,<h1>bench</h1>';
 const connectTimeoutMs = 30_000;
+const pageOpsTimeoutMs = 60_000;
 const closeTimeoutMs = 15_000;
 const MODES = ['all', 'grid', 'local', 'local-reused'];
 
@@ -43,8 +45,7 @@ const { values: options } = parseArgs({
 const iterations = parsePositiveInt('--iterations', options.iterations);
 const warmup = parsePositiveInt('--warmup', options.warmup, { min: 0 });
 if (!MODES.includes(options.mode)) {
-  console.error(`--mode must be one of: ${MODES.join(', ')}`);
-  process.exit(1);
+  throw new Error(`--mode must be one of: ${MODES.join(', ')}`);
 }
 const enabled = (mode) => options.mode === 'all' || options.mode === mode;
 
@@ -57,9 +58,16 @@ async function timeToFirstPage(getBrowser, cleanup) {
   const start = performance.now();
   const browser = await getBrowser();
   try {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.goto(PAGE_URL);
+    // A wedged browser could stall any of these without a deadline.
+    await withDeadline(
+      (async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto(PAGE_URL);
+      })(),
+      pageOpsTimeoutMs,
+      'page setup'
+    );
     return performance.now() - start;
   } finally {
     await cleanup(browser);

--- a/bench/time-to-first-page.js
+++ b/bench/time-to-first-page.js
@@ -1,40 +1,51 @@
 // Measures time-to-first-page: how long a client waits between asking for a
 // browser and having a page ready to use.
 //
-//   grid:  chromium.connect(<endpoint>) -> newContext -> newPage -> goto
-//   local: chromium.launch()            -> newContext -> newPage -> goto
+//   grid:         chromium.connect(<endpoint>) -> newContext -> newPage -> goto
+//   local:        chromium.launch()            -> newContext -> newPage -> goto
+//   local-reused: newContext -> newPage -> goto on one browser launched
+//                 upfront (how @playwright/test reuses a worker's browser)
 //
-// The page is a data: URL, so no network time pollutes the numbers. Iterations
-// run sequentially; warmup runs are discarded (they pay one-time costs such as
-// module loading and disk cache).
+// The three baselines answer different questions: "local" is the cost of a
+// browser per task; "local-reused" is the floor a warm local browser sets —
+// the grid does not try to beat it, it trades a few milliseconds of relay
+// overhead for isolation and fleet capacity. The page is a data: URL, so no
+// network time pollutes the numbers. Iterations run sequentially; warmup runs
+// are discarded (they pay one-time costs such as module loading and disk
+// cache).
 
 import { parseArgs } from 'node:util';
 import { chromium } from 'playwright';
-import { summarize, formatRow, formatHeader } from './lib.js';
+import { summarize, formatRow, formatHeader, parsePositiveInt, waitForWorkers } from './lib.js';
 
 const PAGE_URL = 'data:text/html,<h1>bench</h1>';
+const connectTimeoutMs = 30_000;
+const MODES = ['all', 'grid', 'local', 'local-reused'];
 
 const { values: options } = parseArgs({
   options: {
     endpoint: { type: 'string', default: 'ws://127.0.0.1:8080' },
     iterations: { type: 'string', default: '30' },
     warmup: { type: 'string', default: '3' },
-    mode: { type: 'string', default: 'both' }, // both | grid | local
+    'expect-workers': { type: 'string', default: '' },
+    mode: { type: 'string', default: 'all' },
   },
 });
 
-const iterations = Number.parseInt(options.iterations, 10);
-const warmup = Number.parseInt(options.warmup, 10);
-if (!Number.isInteger(iterations) || iterations < 1 || !Number.isInteger(warmup) || warmup < 0) {
-  console.error('--iterations must be >= 1 and --warmup must be >= 0');
+const iterations = parsePositiveInt('--iterations', options.iterations);
+const warmup = parsePositiveInt('--warmup', options.warmup, { min: 0 });
+if (!MODES.includes(options.mode)) {
+  console.error(`--mode must be one of: ${MODES.join(', ')}`);
   process.exit(1);
 }
-if (!['both', 'grid', 'local'].includes(options.mode)) {
-  console.error('--mode must be one of: both, grid, local');
-  process.exit(1);
+const enabled = (mode) => options.mode === 'all' || options.mode === mode;
+
+if (options['expect-workers'] && enabled('grid')) {
+  const expectedWorkers = parsePositiveInt('--expect-workers', options['expect-workers']);
+  await waitForWorkers(options.endpoint, expectedWorkers, 1);
 }
 
-async function timeToFirstPage(getBrowser) {
+async function timeToFirstPage(getBrowser, cleanup) {
   const start = performance.now();
   const browser = await getBrowser();
   try {
@@ -43,35 +54,60 @@ async function timeToFirstPage(getBrowser) {
     await page.goto(PAGE_URL);
     return performance.now() - start;
   } finally {
-    await browser.close();
+    await cleanup(browser);
   }
 }
 
-async function run(label, getBrowser) {
+async function run(label, getBrowser, cleanup) {
   for (let i = 0; i < warmup; i++) {
-    await timeToFirstPage(getBrowser);
+    await timeToFirstPage(getBrowser, cleanup);
   }
   const samples = [];
   for (let i = 0; i < iterations; i++) {
-    samples.push(await timeToFirstPage(getBrowser));
+    samples.push(await timeToFirstPage(getBrowser, cleanup));
   }
   return { label, stats: summarize(samples) };
 }
 
+const closeBrowser = (browser) => browser.close();
 const results = [];
-if (options.mode !== 'local') {
-  results.push(await run('grid connect()', () => chromium.connect(options.endpoint)));
+
+if (enabled('grid')) {
+  results.push(
+    await run(
+      'grid connect()',
+      () => chromium.connect(options.endpoint, { timeout: connectTimeoutMs }),
+      closeBrowser
+    )
+  );
 }
-if (options.mode !== 'grid') {
-  results.push(await run('local launch()', () => chromium.launch()));
+if (enabled('local')) {
+  results.push(
+    await run('local launch()', () => chromium.launch({ timeout: connectTimeoutMs }), closeBrowser)
+  );
+}
+if (enabled('local-reused')) {
+  const shared = await chromium.launch({ timeout: connectTimeoutMs });
+  try {
+    // The shared browser outlives every iteration; only its contexts close.
+    results.push(
+      await run(
+        'local reused browser',
+        () => shared,
+        async (browser) => {
+          for (const context of browser.contexts()) {
+            await context.close();
+          }
+        }
+      )
+    );
+  } finally {
+    await shared.close();
+  }
 }
 
 console.log(`time-to-first-page, ${iterations} iterations (${warmup} warmup)\n`);
 console.log(formatHeader());
 for (const { label, stats } of results) {
   console.log(formatRow(label, stats));
-}
-if (results.length === 2) {
-  const [grid, local] = results;
-  console.log(`\ngrid p50 is ${(local.stats.p50 / grid.stats.p50).toFixed(1)}x faster than local launch p50`);
 }

--- a/bench/time-to-first-page.js
+++ b/bench/time-to-first-page.js
@@ -1,0 +1,77 @@
+// Measures time-to-first-page: how long a client waits between asking for a
+// browser and having a page ready to use.
+//
+//   grid:  chromium.connect(<endpoint>) -> newContext -> newPage -> goto
+//   local: chromium.launch()            -> newContext -> newPage -> goto
+//
+// The page is a data: URL, so no network time pollutes the numbers. Iterations
+// run sequentially; warmup runs are discarded (they pay one-time costs such as
+// module loading and disk cache).
+
+import { parseArgs } from 'node:util';
+import { chromium } from 'playwright';
+import { summarize, formatRow, formatHeader } from './lib.js';
+
+const PAGE_URL = 'data:text/html,<h1>bench</h1>';
+
+const { values: options } = parseArgs({
+  options: {
+    endpoint: { type: 'string', default: 'ws://127.0.0.1:8080' },
+    iterations: { type: 'string', default: '30' },
+    warmup: { type: 'string', default: '3' },
+    mode: { type: 'string', default: 'both' }, // both | grid | local
+  },
+});
+
+const iterations = Number.parseInt(options.iterations, 10);
+const warmup = Number.parseInt(options.warmup, 10);
+if (!Number.isInteger(iterations) || iterations < 1 || !Number.isInteger(warmup) || warmup < 0) {
+  console.error('--iterations must be >= 1 and --warmup must be >= 0');
+  process.exit(1);
+}
+if (!['both', 'grid', 'local'].includes(options.mode)) {
+  console.error('--mode must be one of: both, grid, local');
+  process.exit(1);
+}
+
+async function timeToFirstPage(getBrowser) {
+  const start = performance.now();
+  const browser = await getBrowser();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(PAGE_URL);
+    return performance.now() - start;
+  } finally {
+    await browser.close();
+  }
+}
+
+async function run(label, getBrowser) {
+  for (let i = 0; i < warmup; i++) {
+    await timeToFirstPage(getBrowser);
+  }
+  const samples = [];
+  for (let i = 0; i < iterations; i++) {
+    samples.push(await timeToFirstPage(getBrowser));
+  }
+  return { label, stats: summarize(samples) };
+}
+
+const results = [];
+if (options.mode !== 'local') {
+  results.push(await run('grid connect()', () => chromium.connect(options.endpoint)));
+}
+if (options.mode !== 'grid') {
+  results.push(await run('local launch()', () => chromium.launch()));
+}
+
+console.log(`time-to-first-page, ${iterations} iterations (${warmup} warmup)\n`);
+console.log(formatHeader());
+for (const { label, stats } of results) {
+  console.log(formatRow(label, stats));
+}
+if (results.length === 2) {
+  const [grid, local] = results;
+  console.log(`\ngrid p50 is ${(local.stats.p50 / grid.stats.p50).toFixed(1)}x faster than local launch p50`);
+}

--- a/bench/time-to-first-page.js
+++ b/bench/time-to-first-page.js
@@ -16,10 +16,18 @@
 
 import { parseArgs } from 'node:util';
 import { chromium } from 'playwright';
-import { summarize, formatRow, formatHeader, parsePositiveInt, waitForWorkers } from './lib.js';
+import {
+  summarize,
+  formatRow,
+  formatHeader,
+  parsePositiveInt,
+  waitForWorkers,
+  withDeadline,
+} from './lib.js';
 
 const PAGE_URL = 'data:text/html,<h1>bench</h1>';
 const connectTimeoutMs = 30_000;
+const closeTimeoutMs = 15_000;
 const MODES = ['all', 'grid', 'local', 'local-reused'];
 
 const { values: options } = parseArgs({
@@ -69,7 +77,7 @@ async function run(label, getBrowser, cleanup) {
   return { label, stats: summarize(samples) };
 }
 
-const closeBrowser = (browser) => browser.close();
+const closeBrowser = (browser) => withDeadline(browser.close(), closeTimeoutMs, 'browser.close()');
 const results = [];
 
 if (enabled('grid')) {
@@ -96,13 +104,13 @@ if (enabled('local-reused')) {
         () => shared,
         async (browser) => {
           for (const context of browser.contexts()) {
-            await context.close();
+            await withDeadline(context.close(), closeTimeoutMs, 'context.close()');
           }
         }
       )
     );
   } finally {
-    await shared.close();
+    await withDeadline(shared.close(), closeTimeoutMs, 'browser.close()');
   }
 }
 

--- a/scripts/check-playwright-version.js
+++ b/scripts/check-playwright-version.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Ensures the Playwright package version declared in worker/package.json
- * matches the Playwright image tag used in worker/Dockerfile.
+ * Ensures the Playwright package versions declared in worker/package.json and
+ * bench/package.json match the Playwright image tag used in worker/Dockerfile.
  */
 
 const { readFileSync } = require('node:fs');
@@ -12,7 +12,10 @@ const rootDir = resolve(__dirname, '..');
 const workerDir = resolve(rootDir, 'worker');
 
 const dockerfilePath = resolve(workerDir, 'Dockerfile');
-const packageJsonPath = resolve(workerDir, 'package.json');
+const packageJsonPaths = [
+  resolve(workerDir, 'package.json'),
+  resolve(rootDir, 'bench', 'package.json'),
+];
 
 function getDockerfileVersion() {
   const dockerfileContent = readFileSync(dockerfilePath, 'utf-8');
@@ -25,7 +28,7 @@ function getDockerfileVersion() {
   return match[1];
 }
 
-function getPackageJsonVersion() {
+function getPackageJsonVersion(packageJsonPath) {
   const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   const version =
     pkg.dependencies?.['playwright-core'] ??
@@ -50,13 +53,16 @@ function getPackageJsonVersion() {
 
 try {
   const dockerfileVersion = getDockerfileVersion();
-  const packageJsonVersion = getPackageJsonVersion();
 
-  if (dockerfileVersion !== packageJsonVersion) {
-    console.error(
-      `Playwright version mismatch: Dockerfile uses ${dockerfileVersion}, package.json declares ${packageJsonVersion}`
-    );
-    process.exit(1);
+  for (const packageJsonPath of packageJsonPaths) {
+    const packageJsonVersion = getPackageJsonVersion(packageJsonPath);
+
+    if (dockerfileVersion !== packageJsonVersion) {
+      console.error(
+        `Playwright version mismatch: Dockerfile uses ${dockerfileVersion}, ${packageJsonPath} declares ${packageJsonVersion}`
+      );
+      process.exit(1);
+    }
   }
 
   console.log(`Playwright versions match (${dockerfileVersion}).`);


### PR DESCRIPTION
Adds `bench/` — the reproducible benchmark suite behind the numbers the new
README will cite. Two benchmarks, one dedicated compose stack, and the
methodology + measured results in `bench/README.md`.

## What it measures

- **Time-to-first-page** (`time-to-first-page.js`): grid `connect()` vs local
  `launch()` — connect → context → page → goto against a `data:` URL, so no
  network noise. Sequential iterations with discarded warmup.
- **Throughput** (`throughput.js`): completed sessions/s at fixed client
  concurrency, in two modes:
  - *saturation* — unlimited workers on one machine, showing the machine's
    CPU, not the grid, is the ceiling;
  - *scaling* — `WORKER_CPUS` pins each worker to a fixed CPU budget so
    adding a worker simulates adding a fixed-size node.

## Configuration impact

- No changes to `server/` or `worker/` code.
- `bench/docker-compose.yaml` disables worker recycling
  (`MAX_LIFETIME_SESSIONS=0`) so throughput measures service rate rather than
  container restart latency (disclosed in the methodology), and sets
  `restart: unless-stopped` because recycled workers exit by design.
- `scripts/check-playwright-version.js` now also verifies
  `bench/package.json`, and Dependabot's `playwright` multi-ecosystem group
  gains an npm `/bench` entry, so the bench client's Playwright pin moves in
  the same PR as the worker's.

## Numbers

`bench/README.md` deliberately publishes no results: everything so far ran on
a loaded development machine, colocated with the stack. Publishable numbers
will come from a two-machine cloud setup (grid on one standard VM, client on
another) before the main README cites anything. Development-machine runs were
used to validate the suite itself: all three latency variants produce stable
tables, throughput scaling came out linear (1.0x/1.9x/3.0x for 1/2/3
CPU-capped workers) once the methodology was corrected, and per-container
`docker stats` attributed saturation CPU to the browsers, not the
coordination layer.

## Verification

- All three benchmark flows executed against a live stack built from this
  branch (results above; the recycling and restart-policy pitfalls were found
  by hitting them live).
- `node scripts/check-playwright-version.js` passes and fails correctly when
  the bench pin is changed.
- `docker compose -f bench/docker-compose.yaml config --quiet` passes with
  and without `WORKER_CPUS`.
- No server or worker code changed, so their suites were not run.
