### PR TITLE
chore: trim compose comments and verify releases match the compose images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,28 @@ jobs:
           tags: ${{ steps.meta-worker.outputs.tags }}
           labels: ${{ steps.meta-worker.outputs.labels }}
 
+      # docker-compose.yaml deploys `latest`. Prove the tag now points at the
+      # images built for this release, so the documented deployment and the
+      # GitHub release can never name different images. Pre-releases do not
+      # move `latest`, so there is nothing to prove for them.
+      - name: Verify docker-compose.yaml deploys the released images
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          for service in server worker; do
+            image="ghcr.io/${{ github.repository }}/${service}"
+            if ! grep -qF "image: ${image}:latest" docker-compose.yaml; then
+              echo "docker-compose.yaml does not deploy ${image}:latest" >&2
+              exit 1
+            fi
+            released="$(docker buildx imagetools inspect "${image}:${version}" --format '{{.Manifest.Digest}}')"
+            latest="$(docker buildx imagetools inspect "${image}:latest" --format '{{.Manifest.Digest}}')"
+            if [[ "${released}" != "${latest}" ]]; then
+              echo "${image}:latest (${latest}) is not the ${version} release (${released})" >&2
+              exit 1
+            fi
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -20,8 +20,8 @@ services:
       - DATABASE_URL=postgres://pwd:pwd@postgres:5432/pwd?sslmode=disable
     ports:
       - "127.0.0.1:8080:8080"
-    # Shutdown budget: 20s relay grace + 10s worker dial + 9s relay cleanup
-    # + 5s buffer = 44s.
+    # Must exceed the server's shutdown sequence (~44s with the default
+    # SHUTDOWN_GRACE_PERIOD and WORKER_DIAL_TIMEOUT); raise them together.
     stop_grace_period: 60s
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/healthz"]
@@ -32,9 +32,8 @@ services:
       postgres:
         condition: service_healthy
 
-  # Stop budget: each cleanup step is bounded by the worker's 2.5s cleanup
-  # timeout, not its inner deadline. Worst case: 2.5s drain status + 30s drain
-  # + 2.5s shutdown status + 2.5s gateway + 10s browser close + 2.5s kill = 50s.
+  # Worker stop_grace_period must stay above DRAIN_TIMEOUT plus ~20s of
+  # shutdown cleanup; raise them together.
   worker:
     build:
       context: ./worker

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,9 +28,8 @@ services:
       - DATABASE_URL=postgres://pwd:${POSTGRES_PASSWORD:-pwd}@postgres:5432/pwd?sslmode=disable
     ports:
       - "127.0.0.1:8080:8080"
-    # Shutdown budget: 20s relay grace + 10s worker dial + 9s relay cleanup
-    # + 5s buffer = 44s. Raise together with SHUTDOWN_GRACE_PERIOD and
-    # WORKER_DIAL_TIMEOUT.
+    # Must exceed the server's shutdown sequence (~44s with the default
+    # SHUTDOWN_GRACE_PERIOD and WORKER_DIAL_TIMEOUT); raise them together.
     stop_grace_period: 60s
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/healthz"]
@@ -42,9 +41,6 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  # Stop budget: each cleanup step is bounded by the worker's 2.5s cleanup
-  # timeout, not its inner deadline. Worst case: 2.5s drain status + 30s drain
-  # + 2.5s shutdown status + 2.5s gateway + 10s browser close + 2.5s kill = 50s.
   worker:
     image: ghcr.io/mbroton/playwright-distributed/worker:latest
     init: true

--- a/scripts/bench/docker-compose.yaml
+++ b/scripts/bench/docker-compose.yaml
@@ -1,5 +1,5 @@
 # Benchmark stack: postgres + server + N identical chromium workers.
-# Scale the worker count per run (from bench/):
+# Scale the worker count per run (from scripts/bench/):
 #   docker compose up -d --build --scale worker=3
 # The server runs in unauthenticated bootstrap mode (zero API keys), like
 # docker-compose.local.yaml. Do not use it on a public network.
@@ -22,9 +22,8 @@ services:
       dockerfile: Dockerfile
     environment:
       - DATABASE_URL=postgres://pwd:pwd@postgres:5432/pwd?sslmode=disable
-      # Worker recycling (default: drain after 50 lifetime sessions) is
-      # disabled so throughput measures the grid's service rate, not the
-      # container runtime's restart latency. See README.md before changing.
+      # Recycling disabled: the benchmark measures the grid's service rate,
+      # not browser restart latency.
       - MAX_LIFETIME_SESSIONS=0
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
## Behavior changes

- Compose files: the shutdown-budget derivations are replaced by the rule an
  operator needs (which settings to raise together); the duplicate worker
  stop-budget note is removed; the benchmark compose's stale `bench/` path is
  fixed and its recycling note shortened. No configuration values change.
- Release workflow: before the GitHub release is created, a new step verifies
  that `docker-compose.yaml` deploys `ghcr.io/<repo>/{server,worker}:latest`
  and that `latest` resolves to the same digest as the version just pushed.
  Pre-releases skip the check because they do not move `latest`.

## Configuration impact

None.

## Verification

- All three compose files pass `docker compose config`; `release.yml` parses.
- Checked the registry for v0.4.1: `latest`, `0.4.1`, `0.4`, and `0` share
  one digest for both images.
